### PR TITLE
Fix shift_working hours

### DIFF
--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -355,7 +355,7 @@ def shift_working_hours(country, ts):
     """
 
     # check if time series contains more than 24 h
-    time0 = ts.iloc[[0], [0]].index
+    time0 = ts.index[0]
     time24 = time0 + pd.DateOffset(hours=24)
     if not time24 in ts.index:
         logging.warning(
@@ -379,6 +379,7 @@ def shift_working_hours(country, ts):
         # The timeseries is shifted by -1 hour only on weekends
         ts["Day"] = pd.DatetimeIndex(ts.index).day_name()
         one_weekend = pd.DataFrame()
+        counter = 0
         for i, row in ts.iterrows():
             if row["Day"] in ["Saturday", "Sunday"]:
                 counter = 1

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -393,7 +393,7 @@ def shift_working_hours(country, ts):
                     counter = counter + 1
                 else:
                     pass
-        return ts["h0"]
+        return ts.drop("Day", axis=1)
 
     elif country in [
         "Belgium",

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -86,7 +86,7 @@ class TestDemandProfiles:
             mvs_input_directory=self.test_mvs_directory,
         )
 
-        assert a["h0"].sum() == 17.65904126786193
+        assert a["h0"].sum() == 17.65950917551695
 
     def test_heat_demand_exists(self):
 


### PR DESCRIPTION
I used the function for getting a demand profile for E-Land and noticed that the added lines were necessary. 