### PR TITLE
Add pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a bug report to help us improve.
+title: "[Bug] Bug_short_description"
+labels: bug
+assignees: ''
+
+---
+
+Describe_the_bug
+
+Checklist to make sure that the bug report ist complete:
+- [ ] OS: *your_operating_system*, *your_distribution*
+- [ ] Branch: *branch_name*, updated on *update_date_and_time*
+- [ ] If applicable: Attach full error message
+- [ ] If applicable: Share screenshots/images of your problem
+- [ ] If applicable: Share used input data
+
+*Please mark above checkboxes as following:*
+- [ ] Open
+- [x] Done
+
+:x: Checkbox is not applicable to this bug report

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Create an issue here - for bugs use the bug report above.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+Fix #Issue
+
+**Changes proposed in this pull request**:
+- Your_changes
+
+The following steps were realized, as well (if applies):
+- [ ] Use in-line comments to explain your code
+- [ ] Write docstrings to your code
+- [ ] For new functionalities: Explain in readthedocs
+- [ ] Write test(s) for your new patch of code
+- :x: Update the CHANGELOG.md (let's start this after the first release)
+- [ ] Apply black (`black . --exclude docs/`)
+
+
+*Please mark above checkboxes as following:*
+- [ ] Open
+- [x] Done
+
+:x: Check not applicable to this PR
+
+<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>


### PR DESCRIPTION
Fix #23 

As the number of people working with pvcompare will grow during the next months it's wise to use templates for PRs and bug reports.