### PR TITLE
Remove oemof from requirements as it is installed with MVS setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ reverse_geocoder
 staticmap
 pyppeteer
 demandlib
-oemof
 pdfkit==0.6.1
 xarray==0.15.0
 feedinlib==0.1.0rc2

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,8 @@ setup(
         # "feedinlib == v0.1.0rc2",  # travis has problems with installment todo
         "numpy >= 1.12.0,  < 1.17",
         "pandas >= 0.18.1, < 0.25",
-        "oemof == 0.3.1",
         "scipy",
-        # "mvs_tool", # todo NOTE: fovr now clone mvs_tool and install via "pip install -e ..."
+        # "mvs_tool", # todo NOTE: for now clone mvs_tool and install via "pip install -e ..."
         "workalendar < 7.0.0",  # todo check if needed. Problems with installing skyfield in travis tests (from workalendar 7.0.0)
     ],
     extras_require={"dev": ["pytest"]},


### PR DESCRIPTION

**Changes proposed in this pull request**:
- Remove oemof from requirements as it is installed with MVS setup.py

The following steps were realized, as well (if applies):
:x: Use in-line comments to explain your code
:x: Write docstrings to your code
:x: For new functionalities: Explain in readthedocs
:x: Write test(s) for your new patch of code
:x: Update the CHANGELOG.md (let's start this after the first release)
:x: Apply black (`black . --exclude docs/`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
