### PR TITLE
Move test requirements to setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ addons:
 # command to install dependencies
 install:
   - pip install -r requirements.txt
-  - python setup.py install
-  - pip install -r tests/test_requirements.txt
+  - pip install .[dev]
 
 # commands to run tests
 script:

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,12 @@ setup(
     #     # 'greco_technologies @ git+https://github.com/greco-project/greco_technologies.git@dev#egg=greco_technologies-0',
     #     # 'cpvlib @ git+https://github.com/isi-ies-group/cpvlib.git@pvlib=0.8_fix#egg=cpvlib-0',
     # ],
-    extras_require={"dev": ["pytest"]},
+    extras_require={
+        "dev": [
+            "pytest==5.3.5",
+            "black==19.10b0",
+            "coverage==5.0.3",
+            "coveralls==1.11.0",
+        ]
+    },
 )

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,4 +1,0 @@
-pytest==5.3.5
-black==19.10b0
-coverage==5.0.3
-coveralls==1.11.0


### PR DESCRIPTION


**Changes proposed in this pull request**:
- Move test requirements to setup - install via `pip install .[dev]`

The following steps were realized, as well (if applies):
- [ ] Apply black (`black . --exclude docs/`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
