### PR TITLE
Fix/hp chiller temps

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -226,10 +226,9 @@ The following list will give a brief introduction into the description of the cs
     *Parameters that describe characteristics of the heat pumps and chillers in the simulated energy system.*
 
     1. **mode**: str, options: 'heat_pump' or 'chiller'
-    2. **quality_grade**: float, scale-down factor to determine the COP of a real machine, default: heat pump: 0.2, chiller 0.25 (tests were made with monitored data from the GRECO project, reference follows)
-<<<<<<< HEAD
-    3. **temp_high**: float, high temperature of the sink (external outlet temperature at the condenser)
-    4. **temp_low**: float, temperature of the source (external outlet temperature at the evaporator), default: heating 15 °C ('Reference <http://wiki.energie-m.de/Heizgrenztemperatur>`_)  or 17 °C (`Reference <https://www.hotmaps-project.eu/wp-content/uploads/2018/03/D2.3-Hotmaps_for-upload_revised-final_.pdf>`_)
+    2. **quality_grade**: float, scale-down factor to determine the COP of a real machine, default: heat pump: 0.35, chiller 0.3 (Obtained from `monitored data <https://oemof-thermal.readthedocs.io/en/latest/validation_compression_heat_pumps_and_chillers.html>`_ of the GRECO project)
+    3. **temp_high**: float, temperature in °C of the sink (external outlet temperature at the condenser), default: heat pump: 35 (For the heat pump temp_high has been chosen from the highest value of the evaporators temperature in the `monitored data <https://oemof-thermal.readthedocs.io/en/latest/validation_compression_heat_pumps_and_chillers.html>`_. )
+    4. **temp_low**: float, temperature in °C of the source (external outlet temperature at the evaporator), default: chiller: 15 (The low temperature has been set for now to 15° C, a temperature lower the comfort temperature of 20–22 °C. The chiller has not been implemented in the model yet. However, should it been done so in the future, these temperatures must be researched and adjusted.)
     5. **factor_icing**: float or None, COP reduction caused by icing, only for `mode` 'heat_pump', default: None
     6. **temp_threshold_icing**: float or None, Temperature below which icing occurs, only for `mode` 'heat_pump', default: None
 

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -226,8 +226,8 @@ The following list will give a brief introduction into the description of the cs
 
     1. **mode**: str, options: 'heat_pump' or 'chiller'
     2. **quality_grade**: float, scale-down factor to determine the COP of a real machine, default: heat pump: 0.2, chiller 0.25 (tests were made with monitored data from the GRECO project, reference follows)
-    3. **room_temperature**: float, mean temperature of the room that is heated/cooled, will be adapted with issue #59
-    4. **start_temperature**: float, temperature at which the heating/cooling period starts, default: heating 17 °C (`Reference <https://www.hotmaps-project.eu/wp-content/uploads/2018/03/D2.3-Hotmaps_for-upload_revised-final_.pdf>`_)
+    3. **temp_high**: float, high temperature of the sink (external outlet temperature at the condenser)
+    4. **temp_low**: float, temperature of the source (external outlet temperature at the evaporator), default: heating 15 °C ('Reference <http://wiki.energie-m.de/Heizgrenztemperatur>`_)  or 17 °C (`Reference <https://www.hotmaps-project.eu/wp-content/uploads/2018/03/D2.3-Hotmaps_for-upload_revised-final_.pdf>`_)
     5. **factor_icing**: float or None, COP reduction caused by icing, only for `mode` 'heat_pump', default: None
     6. **temp_threshold_icing**: float or None, Temperature below which icing occurs, only for `mode` 'heat_pump', default: None
 

--- a/pvcompare/data/inputs/heat_pumps_and_chillers.csv
+++ b/pvcompare/data/inputs/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
-mode,quality_grade,room_temperature,start_temperature,factor_icing,temp_threshold_icing
-heat_pump,0.2,20,17,None,None
-chiller,0.25,20,25,,
+mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
+heat_pump,0.35,35,15,None,None
+chiller,0.3,25,15,,

--- a/pvcompare/data/inputs/heat_pumps_and_chillers.csv
+++ b/pvcompare/data/inputs/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
 mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
-heat_pump,0.35,35,nan,None,None
-chiller,0.3,nan,15,,
+heat_pump,0.35,35,,None,None
+chiller,0.3,,15,,

--- a/pvcompare/data/inputs/heat_pumps_and_chillers.csv
+++ b/pvcompare/data/inputs/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
 mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
-heat_pump,0.35,35,15,None,None
-chiller,0.3,20,15,,
+heat_pump,0.35,35,nan,None,None
+chiller,0.3,nan,15,,

--- a/pvcompare/data/inputs/heat_pumps_and_chillers.csv
+++ b/pvcompare/data/inputs/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
 mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
 heat_pump,0.35,35,15,None,None
-chiller,0.3,25,15,,
+chiller,0.3,20,15,,

--- a/pvcompare/heat_pump_and_chiller.py
+++ b/pvcompare/heat_pump_and_chiller.py
@@ -20,8 +20,8 @@ def calculate_cops_and_eers(
     weather,
     lat,
     lon,
+    mode,
     temperature_col="temp_air",
-    mode="heat_pump",
     input_directory=None,
     mvs_input_directory=None,
 ):

--- a/pvcompare/heat_pump_and_chiller.py
+++ b/pvcompare/heat_pump_and_chiller.py
@@ -77,8 +77,8 @@ def calculate_cops_and_eers(
             f"Parameter `mode` should be 'heat_pump' or 'chiller' but is {mode}"
         )
     # prepare parameters for calc_cops
-    start_temperature = float(parameters.start_temperature)
-    room_temperature = [float(parameters.room_temperature)]
+    low_temperature = float(parameters.temp_low)
+    high_temperature = [float(parameters.temp_high)]
     quality_grade = float(parameters.quality_grade)
 
     # prepare ambient temperature for calc_cops (list)
@@ -103,7 +103,7 @@ def calculate_cops_and_eers(
         )
 
         efficiency = cmpr_hp_chiller.calc_cops(
-            temp_high=room_temperature,
+            temp_high=high_temperature,
             temp_low=ambient_temperature,
             quality_grade=quality_grade,
             mode=mode,
@@ -118,7 +118,7 @@ def calculate_cops_and_eers(
     elif mode == "chiller":
         efficiency = cmpr_hp_chiller.calc_cops(
             temp_high=ambient_temperature,
-            temp_low=room_temperature,
+            temp_low=low_temperature,
             quality_grade=quality_grade,
             mode=mode,
         )

--- a/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
+++ b/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
 mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
-heat_pump,0.35,35,nan,None,None
-chiller,0.3,nan,15,,
+heat_pump,0.35,35,,None,None
+chiller,0.3,,15,,

--- a/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
+++ b/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
-mode,quality_grade,room_temperature,start_temperature,factor_icing,temp_threshold_icing
-heat_pump,0.2,26.85,17,None,None
-chiller,0.25,20.0,25,,
+mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
+heat_pump,0.35,35,15,None,None
+chiller,0.3,20,15,,

--- a/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
+++ b/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
 mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
-heat_pump,0.35,35,15,None,None
-chiller,0.3,20,15,,
+heat_pump,0.35,35,nan,None,None
+chiller,0.3,nan,15,,

--- a/tests/test_heat_pump_and_chiller.py
+++ b/tests/test_heat_pump_and_chiller.py
@@ -206,9 +206,7 @@ class TestAddSectorCoupling:
     def test_add_sector_coupling_multiple_heat_pumps(self):
         pass
 
-    def test_add_sector_coupling_warning_no_heat_demand_in_energy_consumption(
-        self,
-    ):
+    def test_add_sector_coupling_warning_no_heat_demand_in_energy_consumption(self,):
         pass
 
     def test_add_sector_coupling_no_warning(self):

--- a/tests/test_heat_pump_and_chiller.py
+++ b/tests/test_heat_pump_and_chiller.py
@@ -31,9 +31,14 @@ class TestCalculateCopsAndEers:
             mvs_input_directory=TEST_DATA_HEAT,
         )
         cops_exp = pd.Series(
-            [4.65885529157667388489, 3.83134991119005308136,
-             3.26825757575757558371, 3.08149999999999968381,
-             2.83822368421052617649, 13.48156249999999900524],
+            [
+                4.65885529157667388489,
+                3.83134991119005308136,
+                3.26825757575757558371,
+                3.08149999999999968381,
+                2.83822368421052617649,
+                13.48156249999999900524,
+            ],
             index=self.date_range,
             name="no_unit",
         )
@@ -61,9 +66,14 @@ class TestCalculateCopsAndEers:
             mvs_input_directory=TEST_DATA_HEAT,
         )
         cops_exp = pd.Series(
-            [4.658855291576674, 3.831349911190053,
-             3.268257575757576, 2.465199999999999,
-             2.270578947368421, 13.481562499999999],
+            [
+                4.658855291576674,
+                3.831349911190053,
+                3.268257575757576,
+                2.465199999999999,
+                2.270578947368421,
+                13.481562499999999,
+            ],
             index=self.date_range,
             name="no_unit",
         )
@@ -196,7 +206,9 @@ class TestAddSectorCoupling:
     def test_add_sector_coupling_multiple_heat_pumps(self):
         pass
 
-    def test_add_sector_coupling_warning_no_heat_demand_in_energy_consumption(self,):
+    def test_add_sector_coupling_warning_no_heat_demand_in_energy_consumption(
+        self,
+    ):
         pass
 
     def test_add_sector_coupling_no_warning(self):

--- a/tests/test_heat_pump_and_chiller.py
+++ b/tests/test_heat_pump_and_chiller.py
@@ -31,7 +31,9 @@ class TestCalculateCopsAndEers:
             mvs_input_directory=TEST_DATA_HEAT,
         )
         cops_exp = pd.Series(
-            [4.0, 3.0, 2.4144869215291727, 2.234636871508378, 2.01005025125628, 0.0],
+            [4.65885529157667388489, 3.83134991119005308136,
+             3.26825757575757558371, 3.08149999999999968381,
+             2.83822368421052617649, 13.48156249999999900524],
             index=self.date_range,
             name="no_unit",
         )
@@ -59,10 +61,15 @@ class TestCalculateCopsAndEers:
             mvs_input_directory=TEST_DATA_HEAT,
         )
         cops_exp = pd.Series(
-            [4.0, 3.0, 2.4144869215291727, 1.7877094972067027, 1.608040201005024, 0.0,],
+            [4.658855291576674, 3.831349911190053,
+             3.268257575757576, 2.465199999999999,
+             2.270578947368421, 13.481562499999999],
             index=self.date_range,
             name="no_unit",
         )
+
+        cops = cops.round(10)
+        cops_exp = cops_exp.round(10)
         assert_series_equal(cops, cops_exp)
 
     def test_calculate_cops_and_eers_chiller(self):


### PR DESCRIPTION
Fix #Issue https://github.com/greco-project/pvcompare/issues/59

With this PR the wrong definition of the temperatures are fixed in the code.
start_temperature is obsolete under the current state of heat_pump_and_chiller.py. 
room_temperature cannot be determined as described in the issue. For this reason temp_high and temp_low were passed for both technologies.

Furthermore for both technologies the quality grades had been chosen from UPM's validation data (https://oemof-thermal.readthedocs.io/en/latest/validation_compression_heat_pumps_and_chillers.html)
For the heat pump temp_high has been chosen from the highest value of the evaporators temperature during UPM's measurement. For temp_low the heating limit temperature (Heizgrenztemperatur) has been chosen.

The temperature of the chiller could not be obtained from the measurements since other temperature ranges had been driven there. The low temperature has been set for now to 15° C, a temperature lower the comfort temperature of 20–22 °C.
temp_high has been set to 20° C (leaving a range of 5 °C between both temperatures for operation). The chiller has not been implemented in the model yet. However, should it been done so in the future, these temperatures must be researched and adjusted.


The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [x] Apply black (`black . --exclude docs/`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
