### PR TITLE
Remove summer heat demand and distributes excess demand over the profile

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -214,13 +214,14 @@ The following list will give a brief introduction into the description of the cs
     4. **length south facade**: int, length of the south facade in m
     5. **length eastwest facade**:int, length of the east/west facade in m
     6. **hight storey**: int, hight of each storey in m
-    7. **filename_total_consumption**: str, name of the csv file that contains the total electricity and heat consumption for EU countries in different years from [2] *
-    8. **filename_total_SH**: str, name of the csv file that contains the total space heating for EU countries in different years [2] *
-    9. **filename_total_WH**: str, name of the csv file that contains the total water heating for EU countries in different years [2] *
-    10. **filename_elect_SH**: str, name of the csv file that contains the electrical space heatig for EU countries in different years [2] *
-    11. **filename_elect_WH**: str, name of the csv file that contains the electrical water heating for EU countries in different years [2] *
-    12. **filename_residential_electricity_demand**: str, name of the csv file that contains the total residential electricity demand for EU countries in different years [2] *
-    13. **filename_country_population**: str, name of the csv file that contains population for EU countries in different years [2] *
+    7. **heating limit temperature**: int, temperature limit for space heating in °C, default: `15 °C <http://wiki.energie-m.de/Heizgrenztemperatur>`_
+    8. **filename_total_consumption**: str, name of the csv file that contains the total electricity and heat consumption for EU countries in different years from [2] *
+    9. **filename_total_SH**: str, name of the csv file that contains the total space heating for EU countries in different years [2] *
+    10. **filename_total_WH**: str, name of the csv file that contains the total water heating for EU countries in different years [2] *
+    11. **filename_elect_SH**: str, name of the csv file that contains the electrical space heatig for EU countries in different years [2] *
+    12. **filename_elect_WH**: str, name of the csv file that contains the electrical water heating for EU countries in different years [2] *
+    13. **filename_residential_electricity_demand**: str, name of the csv file that contains the total residential electricity demand for EU countries in different years [2] *
+    14. **filename_country_population**: str, name of the csv file that contains population for EU countries in different years [2] *
 
 * heat_pumps_and_chillers:
     *Parameters that describe characteristics of the heat pumps and chillers in the simulated energy system.*

--- a/pvcompare/data/inputs/building_parameters.csv
+++ b/pvcompare/data/inputs/building_parameters.csv
@@ -6,6 +6,7 @@ length south facade,56
 length eastwest facade,22
 hight storey,3
 heating limit temperature,15
+include warm water,True
 filename_total_consumption,total_consumption_residential.csv
 filename_total_SH,total_consumption_residential_SH.csv
 filename_total_WH,total_consumption_residential_WH.csv

--- a/pvcompare/data/inputs/building_parameters.csv
+++ b/pvcompare/data/inputs/building_parameters.csv
@@ -5,6 +5,7 @@ total storey area,1232
 length south facade,56
 length eastwest facade,22
 hight storey,3
+heating limit temperature,15
 filename_total_consumption,total_consumption_residential.csv
 filename_total_SH,total_consumption_residential_SH.csv
 filename_total_WH,total_consumption_residential_WH.csv

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -332,16 +332,14 @@ def calculate_heat_demand(
     # convert Mtoe in kWh
     # Heat demand of residential for space heating
     heat_demand = (
-        total_SH.at[country, str(year)]
-        - electr_SH.at[country, str(year)]
+        total_SH.at[country, str(year)] - electr_SH.at[country, str(year)]
     ) * 11630000000
     annual_heat_demand_per_population = (
         heat_demand / populations.at[country, str(year)]
     ) * population
     # Heat demand of households for water heating
     heat_demand_ww = (
-        total_WH.at[country, str(year)]
-        - electr_WH.at[country, str(year)]
+        total_WH.at[country, str(year)] - electr_WH.at[country, str(year)]
     ) * 11630000000
     annual_heat_demand_ww_per_population = (
         heat_demand_ww / populations.at[country, str(year)]
@@ -430,7 +428,7 @@ def calculate_heat_demand(
 def adjust_heat_demand(temperature, heating_limit_temp, demand):
     """
     Adjust the hourly heat demand setting a limit to the temperature of heating
-    
+
     Heat demand above the heating limit temperature is set to zero
     Excess heat demand is then distributed equally over the remaining hourly heat demand
 

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -348,7 +348,7 @@ def calculate_heat_demand(
     ) * population
 
     # Multi family house (mfh: Mehrfamilienhaus)
-    include_warm_water = False  # Set true to include warm water
+    include_warm_water = eval(bp.at["include warm water", "value"])
 
     # Calculate heat demand only for space heating
     demand["h0"] = bdew.HeatBuilding(

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -338,6 +338,7 @@ def calculate_heat_demand(
     ) * population
 
     # Multi family house (mfh: Mehrfamilienhaus)
+    include_warm_water = False  # Set true to include warm water
     demand["h0"] = bdew.HeatBuilding(
         demand.index,
         holidays=holidays,
@@ -347,12 +348,13 @@ def calculate_heat_demand(
         wind_class=0,
         annual_heat_demand=annual_heat_demand_per_population,
         name="MFH",
-        ww_incl=False,
+        ww_incl=include_warm_water,
     ).get_bdew_profile()
 
     # Adjust the heat demand so there is no demand if daily mean temperature
     # is above the heating limit temperature
-    demand = adjust_heat_demand(temp, demand)
+    if not include_warm_water:
+        demand = adjust_heat_demand(temp, demand)
 
     shifted_heat_demand = shift_working_hours(country=country, ts=demand)
     shifted_heat_demand.rename(columns={"h0": "kWh"}, inplace=True)

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -385,15 +385,15 @@ def adjust_heat_demand(temperature, demand):
     excess_demand = 0
     heating_limit_temp = 15
     # Check for every day in the year the mean temperature
-    for i, temp in enumerate(np.arange(0, len(temperature)-24, 24)):
+    for i, temp in enumerate(np.arange(0, len(temperature) - 24, 24)):
         # Calculate mean temperature of a day
-        mean_temp = np.mean(temperature[temp:temp+24])
+        mean_temp = np.mean(temperature[temp : temp + 24])
         # Check if the daily mean temperature is higher than the heating limit temperature
         if mean_temp >= heating_limit_temp:
             # Gather the previous demand calculated by the demandlib in excess_demand
-            excess_demand = excess_demand + sum(demand["h0"][temp:temp+24])
+            excess_demand = excess_demand + sum(demand["h0"][temp : temp + 24])
             # Set heat demand to zero
-            demand["h0"][temp:temp + 24] = 0
+            demand["h0"][temp : temp + 24] = 0
 
     # Count the hours where heat demand is not zero
     count_demand_hours = np.count_nonzero(demand["h0"])

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -361,7 +361,7 @@ def calculate_heat_demand(
         wind_class=0,
         annual_heat_demand=annual_heat_demand_per_population,
         name="MFH",
-        ww_incl=False,
+        ww_incl=False,  # This must be False. Warm water calc follows
     ).get_bdew_profile()
 
     # Read heating limit temperature

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -332,16 +332,16 @@ def calculate_heat_demand(
     # convert Mtoe in kWh
     # Heat demand of residential for space heating
     heat_demand = (
-        total_SH.at[country, str(year)]  #       + total_WH.at[country, str(year)]
-        - electr_SH.at[country, str(year)]  #       - electr_WH.at[country, str(year)]
+        total_SH.at[country, str(year)]
+        - electr_SH.at[country, str(year)]
     ) * 11630000000
     annual_heat_demand_per_population = (
         heat_demand / populations.at[country, str(year)]
     ) * population
     # Heat demand of households for water heating
     heat_demand_ww = (
-        total_WH.at[country, str(year)]  # + total_WH.at[country, str(year)]
-        - electr_WH.at[country, str(year)]  # - electr_WH.at[country, str(year)]
+        total_WH.at[country, str(year)]
+        - electr_WH.at[country, str(year)]
     ) * 11630000000
     annual_heat_demand_ww_per_population = (
         heat_demand_ww / populations.at[country, str(year)]

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -305,36 +305,47 @@ def calculate_heat_demand(
     filename_total_SH = os.path.join(
         input_directory, bp.at["filename_total_SH", "value"]
     )
-    #    filename_total_WH = os.path.join(
-    #        input_directory, bp.at["filename_total_WH", "value"]
-    #    )
+    filename_total_WH = os.path.join(
+        input_directory, bp.at["filename_total_WH", "value"]
+    )
     filename_electr_SH = os.path.join(
         input_directory, bp.at["filename_elect_SH", "value"]
     )
-    #    filename_electr_WH = os.path.join(
-    #        input_directory, bp.at["filename_elect_WH", "value"]
-    #    )
+    filename_electr_WH = os.path.join(
+        input_directory, bp.at["filename_elect_WH", "value"]
+    )
 
     total_SH = pd.read_csv(filename_total_SH, sep=":", index_col=0, header=1)
-    #    total_WH = pd.read_csv(filename_total_WH, sep=":", index_col=0, header=1)
+    total_WH = pd.read_csv(filename_total_WH, sep=":", index_col=0, header=1)
     electr_SH = pd.read_csv(filename_electr_SH, sep=":", index_col=0, header=1)
-    #   electr_WH = pd.read_csv(filename_electr_WH, sep=":", index_col=0, header=1)
+    electr_WH = pd.read_csv(filename_electr_WH, sep=":", index_col=0, header=1)
 
     total_SH[str(year)] = pd.to_numeric(total_SH[str(year)], errors="coerce")
-    #    total_WH[str(year)] = pd.to_numeric(total_WH[str(year)], errors="coerce")
+    total_WH[str(year)] = pd.to_numeric(total_WH[str(year)], errors="coerce")
     electr_SH[str(year)] = pd.to_numeric(electr_SH[str(year)], errors="coerce")
-    #   electr_WH[str(year)] = pd.to_numeric(electr_WH[str(year)], errors="coerce")
+    electr_WH[str(year)] = pd.to_numeric(electr_WH[str(year)], errors="coerce")
 
     filename_population = bp.at["filename_country_population", "value"]
     filename1 = os.path.join(input_directory, filename_population)
     populations = pd.read_csv(filename1, index_col=0, sep=",")
+
     # convert Mtoe in kWh
+    # Heat demand of residential for space heating
     heat_demand = (
         total_SH.at[country, str(year)]  #       + total_WH.at[country, str(year)]
         - electr_SH.at[country, str(year)]  #       - electr_WH.at[country, str(year)]
     ) * 11630000000
     annual_heat_demand_per_population = (
         heat_demand / populations.at[country, str(year)]
+    ) * population
+    # Heat demand of households for water heating
+    heat_demand_ww = (
+        total_WH.at[country, str(year)]  # + total_WH.at[country, str(year)]
+        - electr_WH.at[country, str(year)]  # - electr_WH.at[country, str(year)]
+    ) * 11630000000
+
+    annual_heat_demand_ww_per_population = (
+        heat_demand_ww / populations.at[country, str(year)]
     ) * population
 
     # Multi family house (mfh: Mehrfamilienhaus)

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -343,7 +343,6 @@ def calculate_heat_demand(
         total_WH.at[country, str(year)]  # + total_WH.at[country, str(year)]
         - electr_WH.at[country, str(year)]  # - electr_WH.at[country, str(year)]
     ) * 11630000000
-
     annual_heat_demand_ww_per_population = (
         heat_demand_ww / populations.at[country, str(year)]
     ) * population
@@ -431,6 +430,7 @@ def calculate_heat_demand(
 def adjust_heat_demand(temperature, heating_limit_temp, demand):
     """
     Adjust the hourly heat demand setting a limit to the temperature of heating
+    
     Heat demand above the heating limit temperature is set to zero
     Excess heat demand is then distributed equally over the remaining hourly heat demand
 

--- a/pvcompare/demand.py
+++ b/pvcompare/demand.py
@@ -451,7 +451,7 @@ def adjust_heat_demand(temperature, heating_limit_temp, demand):
     """
     excess_demand = 0
     # Check for every day in the year the mean temperature
-    for i, temp in enumerate(np.arange(0, len(temperature) - 24, 24)):
+    for i, temp in enumerate(np.arange(0, len(temperature), 24)):
         # Calculate mean temperature of a day
         mean_temp = np.mean(temperature[temp : temp + 24])
         # Check if the daily mean temperature is higher than the heating limit temperature

--- a/tests/test_data/test_pvcompare_inputs/building_parameters.csv
+++ b/tests/test_data/test_pvcompare_inputs/building_parameters.csv
@@ -6,6 +6,7 @@ length south facade,56
 length eastwest facade,22
 hight storey,3
 heating limit temperature,15
+include warm water,False
 filename_total_consumption,total_consumption_residential.csv
 filename_total_SH,total_consumption_residential_SH.csv
 filename_total_WH,total_consumption_residential_WH.csv

--- a/tests/test_data/test_pvcompare_inputs/building_parameters.csv
+++ b/tests/test_data/test_pvcompare_inputs/building_parameters.csv
@@ -5,6 +5,7 @@ total storey area,1232
 length south facade,56
 length eastwest facade,22
 hight storey,3
+heating limit temperature,15
 filename_total_consumption,total_consumption_residential.csv
 filename_total_SH,total_consumption_residential_SH.csv
 filename_total_WH,total_consumption_residential_WH.csv

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -58,13 +58,16 @@ class TestDemandProfiles:
         self.weather = weather_df
 
         heat_load = pd.DataFrame()
-        heat_load['kWh'] = [5316573.558139059, 5653065.555489632]
+        heat_load["kWh"] = [5316573.558139059, 5653065.555489632]
         self.heat_load = heat_load
 
         bp = pd.read_csv(
-            os.path.join(self.test_input_directory, "building_parameters.csv"), index_col=0
+            os.path.join(self.test_input_directory, "building_parameters.csv"),
+            index_col=0,
         )
-        self.heating_lim_temp = pd.to_numeric(bp.at["heating limit temperature", "value"], errors="coerce")
+        self.heating_lim_temp = pd.to_numeric(
+            bp.at["heating limit temperature", "value"], errors="coerce"
+        )
 
     def test_power_demand_exists(self):
 
@@ -138,7 +141,7 @@ class TestDemandProfiles:
         result = adjust_heat_demand(
             temperature=self.weather["temp_air"],
             heating_limit_temp=self.heating_lim_temp,
-            demand=self.heat_load["kWh"]
+            demand=self.heat_load["kWh"],
         )
 
         assert result.sum() == 10969639.113628691

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -16,6 +16,7 @@ from pvcompare.demand import (
     shift_working_hours,
     get_workalendar_class,
     calculate_heat_demand,
+    adjust_heat_demand,
 )
 
 
@@ -55,6 +56,15 @@ class TestDemandProfiles:
         weather_df.index = ["2014-01-01 13:00:00+00:00", "2014-01-01 14:00:00+00:00"]
         weather_df.index = pd.to_datetime(weather_df.index)
         self.weather = weather_df
+
+        heat_load = pd.DataFrame()
+        heat_load['kWh'] = [5316573.558139059, 5653065.555489632]
+        self.heat_load = heat_load
+
+        bp = pd.read_csv(
+            os.path.join(self.test_input_directory, "building_parameters.csv"), index_col=0
+        )
+        self.heating_lim_temp = pd.to_numeric(bp.at["heating limit temperature", "value"], errors="coerce")
 
     def test_power_demand_exists(self):
 
@@ -122,6 +132,16 @@ class TestDemandProfiles:
         )
 
         assert a["kWh"].sum() == 10969639.113628691
+
+    def test_adjust_heat_demand(self):
+
+        result = adjust_heat_demand(
+            temperature=self.weather["temp_air"],
+            heating_limit_temp=self.heating_lim_temp,
+            demand=self.heat_load["kWh"]
+        )
+
+        assert result.sum() == 10969639.113628691
 
     def test_shift_working_hours(self):
 

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -68,6 +68,7 @@ class TestDemandProfiles:
         self.heating_lim_temp = pd.to_numeric(
             bp.at["heating limit temperature", "value"], errors="coerce"
         )
+        self.include_ww = eval(bp.at["include warm water", "value"])
 
     def test_power_demand_exists(self):
 
@@ -134,7 +135,10 @@ class TestDemandProfiles:
             column="demand_02",
         )
 
-        assert a["kWh"].sum() == 10969639.113628691
+        if not self.include_ww:
+            assert a["kWh"].sum() == 10969639.113628691
+        else:
+            assert a["kWh"].sum() == 11984233.752677418
 
     def test_adjust_heat_demand(self):
 


### PR DESCRIPTION
Fix #Issue https://github.com/greco-project/pvcompare/issues/136

With this PR heat demand during summer is removed from an implemented daily mean temperature (right now 15 °C) on. This excess heat demand is then distributed equally over the remaining heat demand.

The function is used as an enhancement of the [demandlib](https://github.com/oemof/demandlib), which calculates heat demands only above zero. For modelling the heat demand without warm water of dwelling and houses an approach is needed to approximate to the real heating behavior.

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [x] Apply black (`black . --exclude docs/`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
