### PR TITLE
Fix/heat pump chiller year calc

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -226,8 +226,8 @@ The following list will give a brief introduction into the description of the cs
 
     1. **mode**: str, options: 'heat_pump' or 'chiller'
     2. **quality_grade**: float, scale-down factor to determine the COP of a real machine, default: heat pump: 0.2, chiller 0.25 (tests were made with monitored data from the GRECO project, reference follows)
-    3. **room_temperature**: float, mean temperature of the room that is heated/cooled, will be adapted with issue #59
-    4. **start_temperature**: float, temperature at which the heating/cooling period starts, default: heating 17 °C (`Reference <https://www.hotmaps-project.eu/wp-content/uploads/2018/03/D2.3-Hotmaps_for-upload_revised-final_.pdf>`_)
+    3. **temp_high**: float, high temperature of the sink (external outlet temperature at the condenser)
+    4. **temp_low**: float, temperature of the source (external outlet temperature at the evaporator), default: heating 15 °C ('Reference <http://wiki.energie-m.de/Heizgrenztemperatur>`_)  or 17 °C (`Reference <https://www.hotmaps-project.eu/wp-content/uploads/2018/03/D2.3-Hotmaps_for-upload_revised-final_.pdf>`_)
     5. **factor_icing**: float or None, COP reduction caused by icing, only for `mode` 'heat_pump', default: None
     6. **temp_threshold_icing**: float or None, Temperature below which icing occurs, only for `mode` 'heat_pump', default: None
 

--- a/pvcompare/data/inputs/heat_pumps_and_chillers.csv
+++ b/pvcompare/data/inputs/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
-mode,quality_grade,room_temperature,start_temperature,factor_icing,temp_threshold_icing
-heat_pump,0.2,20,17,None,None
-chiller,0.25,20,25,,
+mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
+heat_pump,0.35,35,15,None,None
+chiller,0.3,25,15,,

--- a/pvcompare/data/inputs/heat_pumps_and_chillers.csv
+++ b/pvcompare/data/inputs/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
 mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
-heat_pump,0.35,35,15,None,None
-chiller,0.3,20,15,,
+heat_pump,0.35,35,nan,None,None
+chiller,0.3,nan,15,,

--- a/pvcompare/data/inputs/heat_pumps_and_chillers.csv
+++ b/pvcompare/data/inputs/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
 mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
 heat_pump,0.35,35,15,None,None
-chiller,0.3,25,15,,
+chiller,0.3,20,15,,

--- a/pvcompare/heat_pump_and_chiller.py
+++ b/pvcompare/heat_pump_and_chiller.py
@@ -20,8 +20,8 @@ def calculate_cops_and_eers(
     weather,
     lat,
     lon,
+    mode,
     temperature_col="temp_air",
-    mode="heat_pump",
     input_directory=None,
     mvs_input_directory=None,
 ):

--- a/pvcompare/heat_pump_and_chiller.py
+++ b/pvcompare/heat_pump_and_chiller.py
@@ -77,8 +77,8 @@ def calculate_cops_and_eers(
             f"Parameter `mode` should be 'heat_pump' or 'chiller' but is {mode}"
         )
     # prepare parameters for calc_cops
-    start_temperature = float(parameters.start_temperature)
-    room_temperature = [float(parameters.room_temperature)]
+    low_temperature = float(parameters.temp_low)
+    high_temperature = [float(parameters.temp_high)]
     quality_grade = float(parameters.quality_grade)
 
     # prepare ambient temperature for calc_cops (list)
@@ -103,7 +103,7 @@ def calculate_cops_and_eers(
         )
 
         efficiency = cmpr_hp_chiller.calc_cops(
-            temp_high=room_temperature,
+            temp_high=high_temperature,
             temp_low=ambient_temperature,
             quality_grade=quality_grade,
             mode=mode,
@@ -118,7 +118,7 @@ def calculate_cops_and_eers(
     elif mode == "chiller":
         efficiency = cmpr_hp_chiller.calc_cops(
             temp_high=ambient_temperature,
-            temp_low=room_temperature,
+            temp_low=low_temperature,
             quality_grade=quality_grade,
             mode=mode,
         )

--- a/pvcompare/heat_pump_and_chiller.py
+++ b/pvcompare/heat_pump_and_chiller.py
@@ -9,6 +9,7 @@ import pandas as pd
 import numpy as np
 import os
 import logging
+import maya
 
 import oemof.thermal.compression_heatpumps_and_chillers as cmpr_hp_chiller
 
@@ -85,7 +86,7 @@ def calculate_cops_and_eers(
     ambient_temperature = weather[temperature_col].values.tolist()
 
     # create add on to filename (year, lat, lon)
-    year = weather.index[int(len(weather) / 2)].year
+    year = maya.parse(weather.index[int(len(weather) / 2)]).datetime().year
     add_on = f"_{year}_{lat}_{lon}"
 
     # calculate COPs or EERs with oemof thermal

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy>=1.12.0,< 1.17
 pandas>=0.18.1,< 0.25
 oemof.thermal>=0.0.3
 scipy
+maya~=0.6.1
 workalendar<7.0.0
 multi_vector_simulator
 git+https://github.com/greco-project/greco_technologies.git@dev

--- a/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
+++ b/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
-mode,quality_grade,room_temperature,start_temperature,factor_icing,temp_threshold_icing
-heat_pump,0.2,26.85,17,None,None
-chiller,0.25,20.0,25,,
+mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
+heat_pump,0.35,35,15,None,None
+chiller,0.3,20,15,,

--- a/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
+++ b/tests/test_data/test_inputs_heat/heat_pumps_and_chillers.csv
@@ -1,3 +1,3 @@
 mode,quality_grade,temp_high,temp_low,factor_icing,temp_threshold_icing
-heat_pump,0.35,35,15,None,None
-chiller,0.3,20,15,,
+heat_pump,0.35,35,nan,None,None
+chiller,0.3,nan,15,,


### PR DESCRIPTION
Fix #Issue https://github.com/greco-project/pvcompare/issues/138

Parsing the date time from weather data with maya makes it possible to run heat_pump_and_chiller.py separately.
I added the maya package to requirements.txt.

I could have converted the string to date time with the datetime library, but this would only allow one format (`"%Y-%m-%d %H:%M:%S%z"`) of the passed date string:
```
    if __name__ == "__main__":
        year = datetime.strptime(weather.index[int(len(weather) / 2)], "%Y-%m-%d %H:%M:%S%z").year
    else:
        year = weather.index[int(len(weather) / 2)].year
```
If the user wants to pass weather data of a different format, maya can parse this as well.


The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [ ] Apply black (`black . --exclude docs/`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
