### PR TITLE
Fix/hp chiller year calc

### DIFF
--- a/pvcompare/heat_pump_and_chiller.py
+++ b/pvcompare/heat_pump_and_chiller.py
@@ -9,6 +9,7 @@ import pandas as pd
 import numpy as np
 import os
 import logging
+import maya
 
 import oemof.thermal.compression_heatpumps_and_chillers as cmpr_hp_chiller
 
@@ -85,7 +86,7 @@ def calculate_cops_and_eers(
     ambient_temperature = weather[temperature_col].values.tolist()
 
     # create add on to filename (year, lat, lon)
-    year = weather.index[int(len(weather) / 2)].year
+    year = maya.parse(weather.index[int(len(weather) / 2)]).datetime().year
     add_on = f"_{year}_{lat}_{lon}"
 
     # calculate COPs or EERs with oemof thermal

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy>=1.12.0,< 1.17
 pandas>=0.18.1,< 0.25
 oemof.thermal>=0.0.3
 scipy
+maya~=0.6.1
 workalendar<7.0.0
 multi_vector_simulator
 git+https://github.com/greco-project/greco_technologies.git@dev


### PR DESCRIPTION
Fix #Issue https://github.com/greco-project/pvcompare/issues/138

Parsing the date time from weather data with maya makes it possible to run heat_pump_and_chiller.py separately.
I added the maya package to requirements.txt.

I could have converted the string to date time with the datetime library, but this would only allow one format (`"%Y-%m-%d %H:%M:%S%z"`) of the passed date string:
```
    if __name__ == "__main__":
        year = datetime.strptime(weather.index[int(len(weather) / 2)], "%Y-%m-%d %H:%M:%S%z").year
    else:
        year = weather.index[int(len(weather) / 2)].year
```
If the user wants to pass weather data of a different format, maya can parse this as well.


The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [ ] Apply black (`black . --exclude docs/`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
