### PR TITLE
Feature/add param scenario description

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -25,6 +25,7 @@ Some parameters can be calculated automatically by *pvcompare* and do not need t
     4. **longitude**: str, 5.875387 * *auto_calc*
     5. **project_id**: str, 1
     6. **project_name**: str, net zero energy community
+    7. **scenario_description**: str, Simulation of scenario scenario_name
 
 * economic_data.csv
     1. **curency**: str, EUR (stands for euro; can be replaced by SEK, if the system is located in Sweden, for instance).

--- a/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/project_data.csv
+++ b/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/project_data.csv
@@ -5,4 +5,5 @@ longitude,str,13.41053
 project_id,str,1
 project_name,str,net zero energy community
 scenario_id,str,1
-scenario_name,str,Scenario_B2
+scenario_name,str,Scenario_example_electricity_sector
+scenario_description,str,Simulation of Scenario_B2

--- a/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/project_data.csv
+++ b/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/project_data.csv
@@ -5,5 +5,5 @@ longitude,str,13.41053
 project_id,str,1
 project_name,str,net zero energy community
 scenario_id,str,1
-scenario_name,str,Scenario_example_electricity_sector
+scenario_name,str,Scenario_B2
 scenario_description,str,Simulation of Scenario_example_electricity_sector

--- a/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/project_data.csv
+++ b/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/project_data.csv
@@ -6,4 +6,4 @@ project_id,str,1
 project_name,str,net zero energy community
 scenario_id,str,1
 scenario_name,str,Scenario_example_electricity_sector
-scenario_description,str,Simulation of Scenario_B2
+scenario_description,str,Simulation of Scenario_example_electricity_sector

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/project_data.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/project_data.csv
@@ -1,8 +1,9 @@
 ,unit,project_data
 country,str,Germany
-latitude,str,48.1351
-longitude,str,11.582
+latitude,str,52.52437
+longitude,str,13.41053
 project_id,str,1
 project_name,str,Template Sector-coupling
 scenario_id,str,1
-scenario_name,str,Scenario 1
+scenario_name,str,Scenario_example_sector_coupling
+scenario_description,str,Simulation of Scenario_example_sector_coupling

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/project_data.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/project_data.csv
@@ -1,9 +1,9 @@
 ,unit,project_data
 country,str,Germany
-latitude,str,52.52437
-longitude,str,13.41053
+latitude,str,48.1351
+longitude,str,11.582
 project_id,str,1
 project_name,str,Template Sector-coupling
 scenario_id,str,1
-scenario_name,str,Scenario_example_sector_coupling
+scenario_name,str,Scenario 1
 scenario_description,str,Simulation of Scenario_example_sector_coupling

--- a/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/project_data.csv
+++ b/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/project_data.csv
@@ -6,3 +6,4 @@ project_id,str,1
 project_name,str,net zero energy community
 scenario_id,str,1
 scenario_name,str,Scenario_B2
+scenario_description,str,Simulation of Scenario_B2

--- a/tests/data/user_inputs/mvs_inputs/csv_elements/project_data.csv
+++ b/tests/data/user_inputs/mvs_inputs/csv_elements/project_data.csv
@@ -6,3 +6,4 @@ project_id,str,1
 project_name,str,net zero energy community
 scenario_id,str,1
 scenario_name,str,Test_scenario_check_inputs
+scenario_description,str,Simulation of Test_scenario_check_inputs


### PR DESCRIPTION
This PR fixes issue https://github.com/greco-project/pvcompare/issues/205

`scenario_description` has been added to

1. `project_data.csv`  (all mvs input folders)
2. `parameters.rst`

This PR can be merged after review or with change of used mvs version in pvcompare to `0.5.5`. The simulation will run either way. You'll just get this warning with mvs=0.5.4:

```
/home/local/RL-INSTITUT/marie-claire.gering/miniconda3/envs/GRECO_env/lib/python3.7/site-packages/multi_vector_simulator/A1_csv_to_json.py:283: WrongParameterWarning: The parameter scenario_description in the file/home/local/RL-INSTITUT/marie-claire.gering/Repositories/pvcompare/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/project_data.csv is not expected. 
Expected parameters are ['country', 'latitude', 'longitude', 'project_id', 'project_name', 'scenario_id', 'scenario_name']
  f"The parameter {i} in the file"
```

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [ ] Apply black (`black . --exclude docs/`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
