### PR TITLE
Update mvs inputs of sector coupling to data in user input collection

### DIFF
--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/economic_data.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/economic_data.csv
@@ -1,5 +1,5 @@
 ,unit,economic_data
-currency,str,NOK
+currency,str,EUR
 project_duration,year,25
 discount_factor,factor,0.07
 tax,factor,0.0

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyConversion.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyConversion.csv
@@ -4,10 +4,10 @@ optimizeCap,bool,True,True
 maximumCap,None or float,None,None
 installedCap,kW,0,0
 age_installed,year,0,0
-lifetime,year,15,12
+lifetime,year,10,12
 development_costs,currency,0,0
-specific_costs,currency/kW,230,450
-specific_costs_om,currency/kW/year,6,42.5
+specific_costs,currency/kW,100,450
+specific_costs_om,currency/kW/year,4,42.5
 dispatch_price,currency/kWh,0,0
 efficiency,factor,0.95,"{'file_name': 'None', 'header': 'no_unit', 'unit': ''}"
 inflow_direction,str,PV bus,Electricity bus

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProduction.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProduction.csv
@@ -1,12 +1,12 @@
-index,unit,pv_plant_01
+index,unit,PV si
 unit,str,kWp
 optimizeCap,bool,True
-maximumCap,None or float,25454.87
+maximumCap,None or float,33576.867
 installedCap,kWp,0
 age_installed,year,0
 lifetime,year,25
-development_costs,currency,500
-specific_costs,currency/unit,500
+development_costs,currency,0
+specific_costs,currency/unit,935
 specific_costs_om,currency/unit/year,50
 dispatch_price,currency/kWh,0
 outflow_direction,str,PV bus

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProviders.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProviders.csv
@@ -1,7 +1,7 @@
 ,unit,Electricity grid
 unit,str,kW
 optimizeCap,bool,True
-energy_price,currency/kWh,0.3
+energy_price,currency/kWh,0.2165
 feedin_tariff,currency/kWh,0.1
 peak_demand_pricing,currency/kW,0
 peak_demand_pricing_period,"times per year (1,2,3,4,6,12)",1

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/fixcost.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/fixcost.csv
@@ -1,8 +1,8 @@
 ,unit,distribution_grid,engineering,operation
 label,str,distribution grid infrastructure,"R&D, engineering",Fix project operation
-age_installed,year,10,0,0
-lifetime,year,30,20,20
+age_installed,year,0,0,0
+lifetime,year,0,0,0
 development_costs,currency,0.0,0,0
 specific_costs,currency,0.0,0,0
-specific_costs_om,currency/year,0,0,4600
+specific_costs_om,currency/year,0,0,0
 dispatch_price,currency/kWh,0,0,0

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/project_data.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/project_data.csv
@@ -1,7 +1,7 @@
 ,unit,project_data
 country,str,Germany
-latitude,str,48.1351
-longitude,str,11.582
+latitude,str,52.52437
+longitude,str,13.41053
 project_id,str,1
 project_name,str,Template Sector-coupling
 scenario_id,str,1


### PR DESCRIPTION
With this PR the mvs inputs data of the sector-coupling example is updated to the values stored in user's inputs collection, since it was outdated.



The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
