### PR TITLE
Add plot_compare_scenarios function to compare KPIs of chosen scenarios

### DIFF
--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -815,7 +815,8 @@ def plot_facades(
             "plot_facades" + str(scenario_name) + "_" + str(variable_name) + ".png",
         )
     )
-    
+
+
 def plot_compare_scenarios(variable_name, kpi, scenario_list, outputs_directory=None):
     """
     kpi: list of str

--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -1076,10 +1076,10 @@ if __name__ == "__main__":
         "Scenario_E4",
         "Scenario_E5",
         "Scenario_E6",
-        "Scenario_D1",
-        "Scenario_D2",
-        "Scenario_D3",
-        "Scenario_D4",
+        "Scenario_F1",
+        "Scenario_F2",
+        "Scenario_F3",
+        "Scenario_F4",
     ]
     plot_compare_scenarios(
         "storeys",

--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -1028,7 +1028,9 @@ def plot_compare_scenarios(variable_name, kpi, scenario_list, outputs_directory=
     for scenario_name in scenario_name_ending:
         name = name + "_" + str(scenario_name)
 
-    fig.savefig(os.path.join(outputs_directory, "plot_scalars" + str(name) + ".png",))
+    fig.savefig(
+        os.path.join(outputs_directory, "plot_compare_scenarios" + str(name) + ".png")
+    )
 
 
 if __name__ == "__main__":

--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -1013,6 +1013,7 @@ def plot_compare_scenarios(variable_name, kpi, scenario_list, outputs_directory=
         # Print minor and major grid lines for better readability
         ax.get_xaxis().set_minor_locator(mpl.ticker.AutoMinorLocator())
         ax.get_yaxis().set_minor_locator(mpl.ticker.AutoMinorLocator())
+        ax.set_ylim(ax.get_ylim()[0], ax.get_ylim()[1] + ax.get_ylim()[1] * 0.1)
         ax.grid(b=True, which="major", axis="both", color="w", linewidth=1.0)
         ax.grid(b=True, which="minor", axis="both", color="w", linewidth=0.5)
 

--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -986,28 +986,31 @@ def plot_compare_scenarios(variable_name, kpi, scenario_list, outputs_directory=
             min_value_year.append(min(df[i]))
             diff_value_year.append(max(df[i]) - min(df[i]))
 
+        scenario_name_ending = []
+        for scenario_name in scenario_list:
+            scenario_name_ending.append(scenario_name.split("_")[1])
         ax.bar(
-            scenario_list,
+            scenario_name_ending,
             max_value_year,
             color="none",
             edgecolor="black",
             linewidth=0.8,
-        )  # Das hier wäre für den Fall dass max_value_year = min_value_year. Es wird dann als Box dargestellt
-        bar = ax.bar(scenario_list, diff_value_year, bottom=min_value_year)
+        )
+        bar = ax.bar(scenario_name_ending, diff_value_year, bottom=min_value_year)
 
         ax.set_ylabel(y_title[i])
-        ax.set_xlabel(variable_name)
+        ax.set_xlabel("Scenario")
         ax.get_yaxis().set_label_coords(-0.13, 0.5)
         ax.set_xlim(ax.get_xlim()[0] - 0.5, ax.get_xlim()[1] + 0.5)
 
-    handles, labels = ax.get_legend_handles_labels()
-    fig.legend(
-        handles,
-        labels,
-        bbox_to_anchor=(0.96, 0.96),
-        loc="upper right",
-        borderaxespad=0.0,
-    )
+    # handles, labels = ax.get_legend_handles_labels()
+    # fig.legend(
+    #     handles,
+    #     labels,
+    #     bbox_to_anchor=(0.96, 0.96),
+    #     loc="upper right",
+    #     borderaxespad=0.0,
+    # )
 
     plt.tight_layout()
 
@@ -1062,9 +1065,28 @@ if __name__ == "__main__":
     #     outputs_directory=None,
     # )
 
-    scenario_list = ["Scenario_E1", "Scenario_E2"]
+    scenario_list = [
+        "Scenario_E1",
+        "Scenario_E2",
+        "Scenario_E3",
+        "Scenario_E4",
+        "Scenario_E5",
+        "Scenario_E6",
+        "Scenario_D1",
+        "Scenario_D2",
+        "Scenario_D3",
+        "Scenario_D4",
+    ]
     plot_compare_scenarios(
         "storeys",
-        ["Degree of NZE", "Degree of autonomy", "Total emissions"],
+        [
+            "Total non-renewable energy",
+            "Self consumption",
+            "Total renewable energy",
+            "Installed capacity PV",
+            "Degree of NZE",
+            "Degree of autonomy",
+            "Total emissions",
+        ],
         scenario_list,
     )

--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -963,8 +963,10 @@ def plot_compare_scenarios(variable_name, kpi, scenario_list, outputs_directory=
     output.sort_index(inplace=True)
 
     # plot
-    hight = len(kpi) * 2
-    fig = plt.figure(figsize=(7, hight))
+    height = len(kpi) * 2
+    fig = plt.figure(figsize=(9, height))
+    color_1 = sns.color_palette()
+    color_2 = sns.color_palette("pastel")
     rows = len(kpi)
     num = (
         rows * 100 + 11
@@ -989,41 +991,48 @@ def plot_compare_scenarios(variable_name, kpi, scenario_list, outputs_directory=
         scenario_name_ending = []
         for scenario_name in scenario_list:
             scenario_name_ending.append(scenario_name.split("_")[1])
+        # Plot bar with maximum value of all three years
         ax.bar(
             scenario_name_ending,
             max_value_year,
-            color="none",
-            edgecolor="black",
-            linewidth=0.8,
+            color=color_1[0],
+            edgecolor=color_1[0],
+            linewidth=0.5,
+            label="KPI minimum of weather years",
         )
-        bar = ax.bar(scenario_name_ending, diff_value_year, bottom=min_value_year)
+        # Plot span between minimum and maximum value of all three years
+        ax.bar(
+            scenario_name_ending,
+            diff_value_year,
+            bottom=min_value_year,
+            edgecolor=color_2[0],
+            linewidth=0.5,
+            color=color_2[0],
+            label="KPI maximum of weather years",
+        )
 
         ax.set_ylabel(y_title[i])
         ax.set_xlabel("Scenario")
         ax.get_yaxis().set_label_coords(-0.13, 0.5)
         ax.set_xlim(ax.get_xlim()[0] - 0.5, ax.get_xlim()[1] + 0.5)
+        # Print minor and major grid lines for better readability
+        ax.get_xaxis().set_minor_locator(mpl.ticker.AutoMinorLocator())
+        ax.get_yaxis().set_minor_locator(mpl.ticker.AutoMinorLocator())
+        ax.grid(b=True, which="major", axis="both", color="w", linewidth=1.0)
+        ax.grid(b=True, which="minor", axis="both", color="w", linewidth=0.5)
 
-    # handles, labels = ax.get_legend_handles_labels()
-    # fig.legend(
-    #     handles,
-    #     labels,
-    #     bbox_to_anchor=(0.96, 0.96),
-    #     loc="upper right",
-    #     borderaxespad=0.0,
-    # )
+    plt.tight_layout(rect=(0.02, 0.03, 1, 1))
 
-    plt.tight_layout()
+    handles, labels = ax.get_legend_handles_labels()
+    fig.legend(
+        handles, labels, loc="lower left", mode="expand",
+    )
 
     name = ""
-    for scenario_name in scenario_list:
+    for scenario_name in scenario_name_ending:
         name = name + "_" + str(scenario_name)
 
-    fig.savefig(
-        os.path.join(
-            outputs_directory,
-            "plot_scalars" + str(name) + "_" + str(variable_name) + ".png",
-        )
-    )
+    fig.savefig(os.path.join(outputs_directory, "plot_scalars" + str(name) + ".png",))
 
 
 if __name__ == "__main__":

--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -821,6 +821,208 @@ def plot_facades(
     )
 
 
+def plot_compare_scenarios(variable_name, kpi, scenario_list, outputs_directory=None):
+    """
+    kpi: list of str
+        List of KPI's to be plotted.
+        Possible entries:
+            "Degree of NZE"
+            "Costs total PV",
+            "Installed capacity PV",
+            "Total renewable energy use",
+            "Renewable share",
+            "LCOE PV",
+            "self consumption",
+            "self sufficiency",
+            "Degree of autonomy",
+            "Total non-renewable energy use"
+    scenario_list: list
+        List with the scenario names that should be compared
+         Notice: all scenarios you want to compare, need to include the
+         loop-outputs for the same variable / steps. The scenario names
+         should follow the scheme: "Scenario_A1", "Scenario_A2", "Scenario_B1" etc.
+    outputs_directory: str
+        Path to output directory.
+        Default: constants.DEFAULT_OUTPUTS_DIRECTORY
+
+    Returns
+    -------
+        None
+        saves figure into `loop_output_directory`
+    -------
+    """
+    # height = len(kpi) * 2
+    # fig = plt.figure(figsize=(7, height))
+
+    output_dict = {}
+    for scenario_name in scenario_list:
+        if outputs_directory == None:
+            outputs_directory = constants.DEFAULT_OUTPUTS_DIRECTORY
+            scenario_folder = os.path.join(outputs_directory, scenario_name)
+        else:
+            scenario_folder = os.path.join(outputs_directory, scenario_name)
+            if not os.path.isdir(scenario_folder):
+                logging.warning(f"The scenario folder {scenario_name} does not exist.")
+        loop_output_directory = os.path.join(
+            scenario_folder, "loop_outputs_" + str(variable_name)
+        )
+        if not os.path.isdir(loop_output_directory):
+            logging.warning(
+                f"The loop output folder {loop_output_directory} does not exist. "
+                f"Please check the variable_name"
+            )
+        # parse through scalars folder and read in all excel sheets
+        output = pd.DataFrame()
+        for filepath in list(
+            glob.glob(os.path.join(loop_output_directory, "scalars", "*.xlsx"))
+        ):
+            file_sheet1 = pd.read_excel(
+                filepath, header=0, index_col=1, sheet_name="cost_matrix1"
+            )
+            file_sheet2 = pd.read_excel(
+                filepath, header=0, index_col=1, sheet_name="scalar_matrix1"
+            )
+            file_sheet3 = pd.read_excel(
+                filepath, header=0, index_col=0, sheet_name="scalars1"
+            )
+
+            # get variable value from filepath
+            split_path = filepath.split("_")
+            get_step = split_path[::-1][0]
+            step = int(get_step.split(".")[0])
+            year = int(split_path[::-1][1])
+            # get all different pv assets
+            csv_directory = os.path.join(
+                scenario_folder,
+                "mvs_outputs_loop_"
+                + str(variable_name)
+                + "_"
+                + str(year)
+                + "_"
+                + str(step),
+                "inputs",
+                "csv_elements",
+            )
+            energyProduction = pd.read_csv(
+                os.path.join(csv_directory, "energyProduction.csv"), index_col=0
+            )
+            energyProduction = energyProduction.drop(["unit"], axis=1)
+            pv_labels = energyProduction.columns
+            # get total costs pv and installed capacity
+            index = str(year) + "_" + str(step)
+            output.loc[index, "step"] = int(step)
+            output.loc[index, "year"] = int(year)
+            for pv in pv_labels:
+                output.loc[index, "Costs total PV"] = file_sheet1.at[pv, "costs_total"]
+                output.loc[index, "Installed capacity PV"] = file_sheet2.at[
+                    pv, "optimizedAddCap"
+                ]
+                output.loc[index, "Total renewable energy"] = file_sheet3.at[
+                    "Total renewable energy use", 0
+                ]
+                output.loc[index, "Renewable factor"] = file_sheet3.at[
+                    "Renewable factor", 0
+                ]
+                output.loc[index, "LCOE PV"] = file_sheet1.at[
+                    pv, "levelized_cost_of_energy_of_asset"
+                ]
+                output.loc[index, "Self consumption"] = file_sheet3.at[
+                    "Onsite energy fraction", 0
+                ]
+                output.loc[index, "Self sufficiency"] = file_sheet3.at[
+                    "Onsite energy matching", 0
+                ]
+                output.loc[index, "Degree of autonomy"] = file_sheet3.at[
+                    "Degree of autonomy", 0
+                ]
+                output.loc[index, "Total emissions"] = file_sheet3.at[
+                    "Total emissions", 0
+                ]
+                output.loc[index, "Total non-renewable energy"] = file_sheet3.at[
+                    "Total non-renewable energy use", 0
+                ]
+                output.loc[index, "Degree of NZE"] = file_sheet3.at["Degree of NZE", 0]
+
+            output_dict_column = output.to_dict()
+            output_dict[scenario_name] = output_dict_column
+    # define y labels
+    y_title = {
+        "Costs total PV": "Costs total PV \n in EUR",
+        "Installed capacity PV": "Installed capacity \nPV in kWp",
+        "Total renewable energy": "Total renewable \nenergy in kWh",
+        "Renewable factor": "Renewable factor \nin %",
+        "LCOE PV": "LCOE PV \nin EUR/kWh",
+        "Self consumption": "Self consumption \nin %",
+        "Self sufficiency": "Self sufficiency \nin %",
+        "Degree of autonomy": "Degree of \nautonomy in %",
+        "Total emissions": "Total emissions \nin kgCO2eq/kWh",
+        "Total non-renewable energy": "Total non-renewable \n energy in kWh",
+        "Degree of NZE": "Degree of NZE \n in %",
+    }
+
+    output.sort_index(inplace=True)
+
+    # plot
+    hight = len(kpi) * 2
+    fig = plt.figure(figsize=(7, hight))
+    rows = len(kpi)
+    num = (
+        rows * 100 + 11
+    )  # the setting for number of rows | number of columns | row number
+
+    for i in kpi:
+        ax = fig.add_subplot(num)
+        num = num + 1
+
+        min_value_year = []
+        max_value_year = []
+        diff_value_year = []
+
+        for key in output_dict.keys():
+            df = pd.DataFrame()
+            df = df.from_dict(output_dict[key])
+
+            max_value_year.append(max(df[i]))
+            min_value_year.append(min(df[i]))
+            diff_value_year.append(max(df[i]) - min(df[i]))
+
+        ax.bar(
+            scenario_list,
+            max_value_year,
+            color="none",
+            edgecolor="black",
+            linewidth=0.8,
+        )  # Das hier wäre für den Fall dass max_value_year = min_value_year. Es wird dann als Box dargestellt
+        bar = ax.bar(scenario_list, diff_value_year, bottom=min_value_year)
+
+        ax.set_ylabel(y_title[i])
+        ax.set_xlabel(variable_name)
+        ax.get_yaxis().set_label_coords(-0.13, 0.5)
+        ax.set_xlim(ax.get_xlim()[0] - 0.5, ax.get_xlim()[1] + 0.5)
+
+    handles, labels = ax.get_legend_handles_labels()
+    fig.legend(
+        handles,
+        labels,
+        bbox_to_anchor=(0.96, 0.96),
+        loc="upper right",
+        borderaxespad=0.0,
+    )
+
+    plt.tight_layout()
+
+    name = ""
+    for scenario_name in scenario_list:
+        name = name + "_" + str(scenario_name)
+
+    fig.savefig(
+        os.path.join(
+            outputs_directory,
+            "plot_scalars" + str(name) + "_" + str(variable_name) + ".png",
+        )
+    )
+
+
 if __name__ == "__main__":
     scenario_name = "Scenario_A2"
     # plot_all_flows(
@@ -852,10 +1054,17 @@ if __name__ == "__main__":
     #     country=country,
     #     static_inputs_directory=None,
     # )
+    #
+    # plot_facades(
+    #     variable_name="technology",
+    #     kpi=["LCOE PV", "Costs total PV", "Installed capacity PV",],
+    #     scenario_name="Scenario_E2",
+    #     outputs_directory=None,
+    # )
 
-    plot_facades(
-        variable_name="technology",
-        kpi=["LCOE PV", "Costs total PV", "Installed capacity PV",],
-        scenario_name="Scenario_E2",
-        outputs_directory=None,
+    scenario_list = ["Scenario_E1", "Scenario_E2"]
+    plot_compare_scenarios(
+        "storeys",
+        ["Degree of NZE", "Degree of autonomy", "Total emissions"],
+        scenario_list,
     )

--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -6,6 +6,7 @@ import pandas as pd
 import shutil
 import glob
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 import logging
 import numpy as np
 import seaborn as sns


### PR DESCRIPTION
With this PR it is possible to produce a plot for the comparison of the KPIs of chosen scenarios as seen in the figure below:

![plot_scalars_E1_E2_E3_E4_E5_E6_F1_F2_F3_F4](https://user-images.githubusercontent.com/52790556/110245482-97311c00-7f63-11eb-92c3-f32b11924015.png)


The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
