### PR TITLE
update PV costs and lifetime for further simulations

### DIFF
--- a/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProduction.csv
+++ b/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProduction.csv
@@ -4,7 +4,7 @@ optimizeCap,bool,True,True,True
 maximumCap,None or float,,,
 installedCap,kWp,0,0,0
 age_installed,year,0,0,0
-lifetime,year,25,25,25
+lifetime,year,25,25,20
 development_costs,currency,0,0,0
 specific_costs,currency/unit,935,1033,836
 specific_costs_om,currency/unit/year,50,27,35

--- a/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProduction.csv
+++ b/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProduction.csv
@@ -4,10 +4,10 @@ optimizeCap,bool,True,True,True
 maximumCap,None or float,,,
 installedCap,kWp,0,0,0
 age_installed,year,0,0,0
-lifetime,year,25,20,15
+lifetime,year,25,25,25
 development_costs,currency,0,0,0
-specific_costs,currency/unit,935,1232.7,816.2
-specific_costs_om,currency/unit/year,50,26.6,31.7
+specific_costs,currency/unit,935,1033,836
+specific_costs_om,currency/unit/year,50,27,35
 dispatch_price,currency/kWh,0,0,0
 outflow_direction,str,PV bus,PV bus,PV bus
 file_name,str,,,


### PR DESCRIPTION
Fix #Issue

**Changes proposed in this pull request**:

- update pv costs cpv and psi and lifetime psi for further simulations:

CPV
specific_costs: 1033
om_costs: 27
lifetime: 25

PSI: 
specific_costs: 836
om_costs: 35
lifetime: 20

A decrease in lifetime PSI does make a difference in the results, because it is generally more expensive to produce. Although, it does not make a huge difference since investment costs are refunded at the end of the project lifetime. This way I would suggest to fix PSI lifetime to 20 years as a first approximation because it seems more realistic to me.

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
