### PR TITLE
Feature/postprocess heat sector

### DIFF
--- a/pvcompare/analysis.py
+++ b/pvcompare/analysis.py
@@ -743,4 +743,4 @@ if __name__ == "__main__":
     #     scenario_name=scenario_name,
     # )
     #
-    # postprocessing_kpi(scenario_name="Scenario_E3", pvcompare_inputs=None, outputs_directory=None)
+    # postprocessing_kpi(scenario_name="Scenario_E3", variable_name="storeys", pvcompare_inputs=None, outputs_directory=None)

--- a/pvcompare/analysis.py
+++ b/pvcompare/analysis.py
@@ -573,10 +573,10 @@ def postprocessing_kpi(
         index_col=0,
     )
 
-    # Calculate the number of households
+    # Calculate the toal number of households
     # and hence obtain number of plants in simulation by assuming
     # that every household has one plant
-    number_plants_per_household = (
+    total_number_households = (
         float(building_params.at["number of houses", "value"])
         * float(building_params.at["number of storeys", "value"])
         * (float(building_params.at["population per storey", "value"]) / 4)
@@ -619,7 +619,7 @@ def postprocessing_kpi(
                 timeseries_heat = pd.read_excel(filepath_t, sheet_name="Heat bus")
                 if "TES output power" in timeseries_heat:
                     # Calculate maximum capacity, nominal capacity and height
-                    # of one heat pump unit and write to scalars
+                    # of one storage unit
                     maximal_tes_capacity = file_sheet2.at[
                         "TES storage capacity", "optimizedAddCap"
                     ]
@@ -640,20 +640,23 @@ def postprocessing_kpi(
                     file_sheet3.at[
                         "Installed capacity per TES", "Unnamed: 0"
                     ] = "Installed capacity per TES"
+                    # Divide total capacity through number of households = number of plants
                     file_sheet3.at["Installed capacity per TES", 0] = (
-                        maximal_tes_capacity / number_plants_per_household
+                        maximal_tes_capacity / total_number_households
                     )
                     file_sheet3.at[
                         "Installed nominal capacity per TES", "Unnamed: 0"
                     ] = "Installed nominal capacity per TES"
+                    # Divide total nominal capacity through number of households = number of plants
                     file_sheet3.at["Installed nominal capacity per TES", 0] = (
-                        nominal_storage_capacity / number_plants_per_household
+                        nominal_storage_capacity / total_number_households
                     )
                     file_sheet3.at[
                         "Height of each TES", "Unnamed: 0"
                     ] = "Height of each TES"
+                    # Divide total height of all TES through number of households = number of plants
                     file_sheet3.at["Height of each TES", 0] = (
-                        height / number_plants_per_household
+                        height / total_number_households
                     )
                 if "Heat pump" in timeseries_heat.columns:
                     # Calculate maximum capacity of one heat pump unit and write to scalars
@@ -661,8 +664,9 @@ def postprocessing_kpi(
                     file_sheet3.at[
                         "Installed capacity per heat pump", "Unnamed: 0"
                     ] = "Installed capacity per heat pump"
+                    # Divide total capacity through number of households = number of plants
                     file_sheet3.at["Installed capacity per heat pump", 0] = (
-                        maximal_hp_capacity / number_plants_per_household
+                        maximal_hp_capacity / total_number_households
                     )
 
                 timeseries = pd.read_excel(filepath_t, sheet_name="Electricity bus")

--- a/pvcompare/analysis.py
+++ b/pvcompare/analysis.py
@@ -2,6 +2,7 @@ import pvcompare.main as main
 import pvcompare.constants as constants
 import os
 import pandas as pd
+import numpy as np
 import shutil
 import glob
 import matplotlib.pyplot as plt
@@ -522,15 +523,19 @@ def loop_mvs(
     )
 
 
-def postprocessing_kpi(scenario_name, variable_name, outputs_directory=None):
+def postprocessing_kpi(scenario_name, pvcompare_inputs=None, outputs_directory=None):
     """
     Overwrites all output excel files "timeseries_all_flows.xlsx" and "scalars.xlsx"
     in loop output directory of a scenario with modified KPI's.
+
     1) Creates new sheet "Electricity bus1" with the column
     Electricity demand = Electricity demand + Heat pump.
     2) Creates new sheets in scalars.xlsx with KPI's adjusted to the new demand.
+
     :param scenario_name: str
         scenario name
+    :param pvcompare_inputs: str
+        pvcompare inputs directory
     :param outputs_directory: str
         output directory
     :return:
@@ -542,82 +547,160 @@ def postprocessing_kpi(scenario_name, variable_name, outputs_directory=None):
         scenario_folder = os.path.join(outputs_directory, scenario_name)
         if not os.path.isdir(scenario_folder):
             logging.warning(f"The scenario folder {scenario_name} does not exist.")
-    # # loop over all loop output folders with variable name
-    loop_output_directory = os.path.join(
-        scenario_folder, "loop_outputs_" + str(variable_name)
+    if pvcompare_inputs == None:
+        pvcompare_inputs = constants.DEFAULT_USER_INPUTS_PVCOMPARE_DIRECTORY
+
+    # Get stratified TES inputs
+    strat_tes_inputs = os.path.join(pvcompare_inputs, "stratified_thermal_storage.csv")
+    if os.path.exists(strat_tes_inputs):
+        strat_tes = pd.read_csv(strat_tes_inputs, index_col=0)
+        heat_capacity = 4195.52
+        density = 971.803
+        temp_h = strat_tes.at["temp_h", "var_value"]
+        temp_c = strat_tes.at["temp_c", "var_value"]
+        diameter = strat_tes.at["diameter", "var_value"]
+
+    # Get number of households in simulation
+    building_params = pd.read_csv(
+        os.path.join(pvcompare_inputs, "building_parameters.csv"), index_col=0
     )
-    if not os.path.isdir(loop_output_directory):
-        logging.warning(
-            f"The loop output folder {loop_output_directory} does not exist. "
-            f"Please check the variable_name"
+
+    number_plants_per_household = (
+        float(building_params.at["number of houses", "value"])
+        * float(building_params.at["number of storeys", "value"])
+        * (float(building_params.at["population per storey", "value"]) / 4)
+    )
+    # get all variable names in scenario folder
+    list_var_name = []
+    for fname in list(glob.glob(os.path.join(scenario_folder, "*"))):
+        folder_name = fname.split("/")[::-1][0]
+        if folder_name.startswith("loop"):
+            split_path = folder_name.split("_")
+            get_var_name = split_path[::-1][0]
+            list_var_name.append(get_var_name)
+    # loop over all loop output folders with variable name
+    for variable_name in list_var_name:
+        loop_output_directory = os.path.join(
+            scenario_folder, "loop_outputs_" + str(variable_name)
         )
-    # parse through scalars folder and read in all excel sheets
-    for filepath_s in list(
-        glob.glob(os.path.join(loop_output_directory, "scalars", "*.xlsx"))
-    ):
-        scalars = pd.read_excel(filepath_s, sheet_name=None)
-
-        # get variable value from filepath
-        split_path = filepath_s.split("_")
-        get_year = split_path[::-1][1]
-        get_step = split_path[::-1][0]
-        ending = str(get_year) + "_" + str(get_step)
-
-        # load timeseries_all_busses
-        for filepath_t in list(
-            glob.glob(os.path.join(loop_output_directory, "timeseries", "*.xlsx"))
-        ):
-            if filepath_t.endswith(ending) is True:
-                timeseries = pd.read_excel(filepath_t, sheet_name="Electricity bus")
-                if "Heat pump" in timeseries.columns:
-                    electricity_demand = (
-                        timeseries["Electricity demand"] + timeseries["Heat pump"]
-                    )
-                    timeseries["Electricity demand"] = electricity_demand
-                    with pd.ExcelWriter(filepath_t, mode="a") as writer:
-                        timeseries.to_excel(writer, sheet_name="Electricity bus")
-                    logging.info(
-                        f"The timeseries_all_flows file {filepath_t} has been overwritten with the new electricity demand."
-                    )
-                else:
-                    electricity_demand = timeseries["Electricity demand"]
-        # read sheets of scalars
-        file_sheet1 = scalars["cost_matrix"]
-        file_sheet2 = scalars["scalar_matrix"]
-        file_sheet2.index = file_sheet2["label"]
-        file_sheet3 = scalars["scalars"]
-        file_sheet3.index = file_sheet3.iloc[:, 0]
-        file_sheet4 = scalars["KPI individual sectors"]
-
-        # recalculate KPI
-        file_sheet2.at["Electricity demand", "total_flow"] = sum(electricity_demand) * (
-            -1
-        )
-        file_sheet3.at["Total_demandElectricity", 0] = sum(electricity_demand) * (-1)
-        file_sheet3.at["Degree of NZE", 0] = (
-            file_sheet3.at["Total internal renewable generation", 0]
-            - file_sheet3.at["Total_excessElectricity", 0]
-        ) / file_sheet3.at["Total_demandElectricity", 0]
-        file_sheet3.at["Degree of autonomy", 0] = (
-            file_sheet3.at["Total_demandElectricity", 0]
-            - file_sheet3.at["Total_consumption_from_energy_providerElectricity", 0]
-        ) / file_sheet3.at["Total_demandElectricity", 0]
-        file_sheet3.at["Onsite energy fraction", 0] = (
-            file_sheet3.at["Total_demandElectricity", 0]
-            - file_sheet3.at["Total_feedinElectricity", 0]
-        ) / file_sheet3.at["Total internal renewable generation", 0]
-
-        # save excel sheets
-        with pd.ExcelWriter(filepath_s, mode="a") as writer:
-            file_sheet1.to_excel(writer, sheet_name="cost_matrix", index=None)
-            file_sheet2.to_excel(writer, sheet_name="scalar_matrix", index=None)
-            file_sheet3.to_excel(writer, sheet_name="scalars", index=None)
-            file_sheet4.to_excel(
-                writer, sheet_name="KPI individual sectors", index=None
+        if not os.path.isdir(loop_output_directory):
+            logging.warning(
+                f"The loop output folder {loop_output_directory} does not exist. "
+                f"Please check the variable_name"
             )
-        logging.info(
-            f"Scalars file sheet {filepath_s} has been overwritten with new KPI's"
-        )
+        # parse through scalars folder and read in all excel sheets
+        for filepath_s in list(
+            glob.glob(os.path.join(loop_output_directory, "scalars", "*.xlsx"))
+        ):
+            # read sheets of scalars
+            scalars = pd.read_excel(filepath_s, sheet_name=None)
+
+            file_sheet1 = scalars["cost_matrix"]
+            file_sheet2 = scalars["scalar_matrix"]
+            file_sheet2.index = file_sheet2["label"]
+            file_sheet3 = scalars["scalars"]
+            file_sheet3.index = file_sheet3.iloc[:, 0]
+            file_sheet4 = scalars["KPI individual sectors"]
+
+            # get variable value from filepath
+            split_path = filepath_s.split("_")
+            get_year = split_path[::-1][1]
+            get_step = split_path[::-1][0]
+            ending = str(get_year) + "_" + str(get_step)
+
+            # load timeseries_all_busses
+            for filepath_t in list(
+                glob.glob(os.path.join(loop_output_directory, "timeseries", "*.xlsx"))
+            ):
+                if filepath_t.endswith(ending) is True:
+                    timeseries_heat = pd.read_excel(filepath_t, sheet_name="Heat bus")
+                    if "TES output power" in timeseries_heat:
+                        # Calculate maximum capacity, nominal capacity and height
+                        # of one heat pump unit and write to scalars
+                        maximal_tes_capacity = file_sheet2.at[
+                            "TES storage capacity", "optimizedAddCap"
+                        ]
+                        nominal_storage_capacity = maximal_tes_capacity * 1.075
+                        volume = (
+                            maximal_tes_capacity
+                            * 1000
+                            / (heat_capacity * density * (temp_h - temp_c) * (1 / 3600))
+                        )
+                        height = volume / (0.25 * np.pi * diameter ** 2)
+                        file_sheet3.at[
+                            "Installed capacity per TES", "Unnamed: 0"
+                        ] = "Installed capacity per TES"
+                        file_sheet3.at["Installed capacity per TES", 0] = (
+                            maximal_tes_capacity / number_plants_per_household
+                        )
+                        file_sheet3.at[
+                            "Installed nominal capacity per TES", "Unnamed: 0"
+                        ] = "Installed nominal capacity per TES"
+                        file_sheet3.at["Installed nominal capacity per TES", 0] = (
+                            nominal_storage_capacity / number_plants_per_household
+                        )
+                        file_sheet3.at[
+                            "Height of each TES", "Unnamed: 0"
+                        ] = "Height of each TES"
+                        file_sheet3.at["Height of each TES", 0] = (
+                            height / number_plants_per_household
+                        )
+
+                    if "Heat pump" in timeseries_heat.columns:
+                        # Calculate maximum capacity of one heat pump unit and write to scalars
+                        maximal_hp_capacity = max(timeseries_heat["Heat pump"])
+                        file_sheet3.at[
+                            "Installed capacity per heat pump", "Unnamed: 0"
+                        ] = "Installed capacity per heat pump"
+                        file_sheet3.at["Installed capacity per heat pump", 0] = (
+                            maximal_hp_capacity / number_plants_per_household
+                        )
+
+                    timeseries = pd.read_excel(filepath_t, sheet_name="Electricity bus")
+                    if "Heat pump" in timeseries.columns:
+                        electricity_demand = (
+                            timeseries["Electricity demand"] + timeseries["Heat pump"]
+                        )
+                        timeseries["Electricity demand"] = electricity_demand
+                        with pd.ExcelWriter(filepath_t, mode="a") as writer:
+                            timeseries.to_excel(writer, sheet_name="Electricity bus")
+                            logging.info(
+                                f"The timeseries_all_flows file {filepath_t} has been overwritten with the new electricity demand."
+                            )
+                    else:
+                        electricity_demand = timeseries["Electricity demand"]
+
+            # recalculate KPI
+            file_sheet2.at["Electricity demand", "total_flow"] = sum(
+                electricity_demand
+            ) * (-1)
+            file_sheet3.at["Total_demandElectricity", 0] = sum(electricity_demand) * (
+                -1
+            )
+            file_sheet3.at["Degree of NZE", 0] = (
+                file_sheet3.at["Total internal renewable generation", 0]
+                - file_sheet3.at["Total_excessElectricity", 0]
+            ) / file_sheet3.at["Total_demandElectricity", 0]
+            file_sheet3.at["Degree of autonomy", 0] = (
+                file_sheet3.at["Total_demandElectricity", 0]
+                - file_sheet3.at["Total_consumption_from_energy_providerElectricity", 0]
+            ) / file_sheet3.at["Total_demandElectricity", 0]
+            file_sheet3.at["Onsite energy fraction", 0] = (
+                file_sheet3.at["Total_demandElectricity", 0]
+                - file_sheet3.at["Total_feedinElectricity", 0]
+            ) / file_sheet3.at["Total internal renewable generation", 0]
+
+            # save excel sheets
+            with pd.ExcelWriter(filepath_s, mode="a") as writer:
+                file_sheet1.to_excel(writer, sheet_name="cost_matrix", index=None)
+                file_sheet2.to_excel(writer, sheet_name="scalar_matrix", index=None)
+                file_sheet3.to_excel(writer, sheet_name="scalars", index=None)
+                file_sheet4.to_excel(
+                    writer, sheet_name="KPI individual sectors", index=None
+                )
+            logging.info(
+                f"Scalars file sheet {filepath_s} has been overwritten with new KPI's"
+            )
 
 
 if __name__ == "__main__":
@@ -670,4 +753,5 @@ if __name__ == "__main__":
     #     scenario_name=scenario_name,
     # )
     #
-    # postprocessing_kpi(scenario_name="Scenario_A9", outputs_directory=None)
+    # postprocessing_kpi(scenario_name="Scenario_E3", pvcompare_inputs=None, outputs_directory=None)
+

--- a/pvcompare/analysis.py
+++ b/pvcompare/analysis.py
@@ -524,7 +524,10 @@ def loop_mvs(
 
 
 def postprocessing_kpi(
-    scenario_name, variable_name, pvcompare_inputs=None, outputs_directory=None
+    scenario_name,
+    variable_name,
+    user_inputs_pvcompare_directory=None,
+    outputs_directory=None,
 ):
     """
     Overwrites all output excel files "timeseries_all_flows.xlsx" and "scalars.xlsx"
@@ -534,7 +537,7 @@ def postprocessing_kpi(
     2) Creates new sheets in scalars.xlsx with KPI's adjusted to the new demand.
     :param scenario_name: str
         scenario name
-    :param pvcompare_inputs: str
+    :param user_inputs_pvcompare_directory: str
         pvcompare inputs directory
     :param outputs_directory: str
         output directory
@@ -547,11 +550,15 @@ def postprocessing_kpi(
         scenario_folder = os.path.join(outputs_directory, scenario_name)
         if not os.path.isdir(scenario_folder):
             logging.warning(f"The scenario folder {scenario_name} does not exist.")
-    if pvcompare_inputs == None:
-        pvcompare_inputs = constants.DEFAULT_USER_INPUTS_PVCOMPARE_DIRECTORY
+    if user_inputs_pvcompare_directory == None:
+        user_inputs_pvcompare_directory = (
+            constants.DEFAULT_USER_INPUTS_PVCOMPARE_DIRECTORY
+        )
 
     # Get stratified TES inputs
-    strat_tes_inputs = os.path.join(pvcompare_inputs, "stratified_thermal_storage.csv")
+    strat_tes_inputs = os.path.join(
+        user_inputs_pvcompare_directory, "stratified_thermal_storage.csv"
+    )
     if os.path.exists(strat_tes_inputs):
         strat_tes = pd.read_csv(strat_tes_inputs, index_col=0)
         heat_capacity = 4195.52
@@ -562,7 +569,8 @@ def postprocessing_kpi(
 
     # Get number of households in simulation
     building_params = pd.read_csv(
-        os.path.join(pvcompare_inputs, "building_parameters.csv"), index_col=0
+        os.path.join(user_inputs_pvcompare_directory, "building_parameters.csv"),
+        index_col=0,
     )
 
     number_plants_per_household = (
@@ -742,4 +750,4 @@ if __name__ == "__main__":
     #     scenario_name=scenario_name,
     # )
     #
-    # postprocessing_kpi(scenario_name="Scenario_E3", variable_name="storeys", pvcompare_inputs=None, outputs_directory=None)
+    # postprocessing_kpi(scenario_name="Scenario_E3", variable_name="storeys", user_inputs_pvcompare_directory=None, outputs_directory=None)

--- a/pvcompare/analysis.py
+++ b/pvcompare/analysis.py
@@ -573,6 +573,9 @@ def postprocessing_kpi(
         index_col=0,
     )
 
+    # Calculate the number of households
+    # and hence obtain number of plants in simulation by assuming
+    # that every household has one plant
     number_plants_per_household = (
         float(building_params.at["number of houses", "value"])
         * float(building_params.at["number of storeys", "value"])
@@ -620,12 +623,19 @@ def postprocessing_kpi(
                     maximal_tes_capacity = file_sheet2.at[
                         "TES storage capacity", "optimizedAddCap"
                     ]
-                    nominal_storage_capacity = maximal_tes_capacity * 1.075
+                    # There is 15 % of unused storage volume according to
+                    # https://op.europa.eu/en/publication-detail/-/publication/312f0f62-dfbd-11e7-9749-01aa75ed71a1/language-en
+                    # The nominal storage capacity is hence the maximum storage capacity multiplied by 1.15
+                    nominal_storage_capacity = maximal_tes_capacity * 1.15
+                    # Calculate volume of TES using oemof-thermal's equations
+                    # in stratified_thermal_storage.py
                     volume = (
                         maximal_tes_capacity
                         * 1000
                         / (heat_capacity * density * (temp_h - temp_c) * (1 / 3600))
                     )
+                    # Calculate height of TES using oemof-thermal's equations
+                    # in stratified_thermal_storage.py
                     height = volume / (0.25 * np.pi * diameter ** 2)
                     file_sheet3.at[
                         "Installed capacity per TES", "Unnamed: 0"

--- a/pvcompare/analysis.py
+++ b/pvcompare/analysis.py
@@ -637,17 +637,16 @@ def postprocessing_kpi(
                     file_sheet3.at["Height of each TES", 0] = (
                         height / number_plants_per_household
                     )
-            if "Heat pump" in timeseries_heat.columns:
-                # Calculate maximum capacity of one heat pump unit and write to scalars
-                maximal_hp_capacity = max(timeseries_heat["Heat pump"])
-                file_sheet3.at[
-                    "Installed capacity per heat pump", "Unnamed: 0"
-                ] = "Installed capacity per heat pump"
-                file_sheet3.at["Installed capacity per heat pump", 0] = (
-                    maximal_hp_capacity / number_plants_per_household
-                )
+                if "Heat pump" in timeseries_heat.columns:
+                    # Calculate maximum capacity of one heat pump unit and write to scalars
+                    maximal_hp_capacity = max(timeseries_heat["Heat pump"])
+                    file_sheet3.at[
+                        "Installed capacity per heat pump", "Unnamed: 0"
+                    ] = "Installed capacity per heat pump"
+                    file_sheet3.at["Installed capacity per heat pump", 0] = (
+                        maximal_hp_capacity / number_plants_per_household
+                    )
 
-            if filepath_t.endswith(ending) is True:
                 timeseries = pd.read_excel(filepath_t, sheet_name="Electricity bus")
                 if "Heat pump" in timeseries.columns:
                     electricity_demand = (

--- a/pvcompare/analysis.py
+++ b/pvcompare/analysis.py
@@ -754,4 +754,3 @@ if __name__ == "__main__":
     # )
     #
     # postprocessing_kpi(scenario_name="Scenario_E3", pvcompare_inputs=None, outputs_directory=None)
-


### PR DESCRIPTION
With this PR the postprocessing of the stratified thermal energy storage (TES) and the heat pump (hp) is added to ` postprocessing_kpi(...)` function in `analysis.py`. For the discussion of the results from simulations of the sector coupled scenarios it is necessary to obtain the installed capacities per household of the heat plants (TES and hp).

Hence the following parameters are calculated and stored in `scalars1` of `scalars.xlsx`:

- Installed capacity per TES
- Installed nominal capacity per TES (theoretical capacity with unused storage volume)
- Height of each TES
- Installed capacity per heat pump





The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md (let's start this after the first release)
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
