### PR TITLE
Improve PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,20 +3,21 @@ Fix #Issue
 **Changes proposed in this pull request**:
 - Your_changes
 
-The following steps were realized, as well (if applies):
+The following steps were realized, as well (required):
+- [ ] Update the CHANGELOG.md (let's start this after the first release)
+- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)
+
+Also the following steps were realized (if applies):
 - [ ] Use in-line comments to explain your code
 - [ ] Write docstrings to your code
 - [ ] For new functionalities: Explain in readthedocs
 - [ ] Write test(s) for your new patch of code
-- [ ] Update the CHANGELOG.md (let's start this after the first release)
-- [ ] Apply black (`black . --exclude docs/`)
-- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)
 
 
 *Please mark above checkboxes as following:*
 - [ ] Open
 - [x] Done
 
-:x: Check not applicable to this PR
+In case of an error due to linting run `black . --exclude docs/` and push your changes.
 
 <sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Fix #Issue
 - Your_changes
 
 The following steps were realized, as well (required):
-- [ ] Update the CHANGELOG.md (let's start this after the first release)
+- [ ] Update the CHANGELOG.md
 - [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)
 
 Also the following steps were realized (if applies):
@@ -18,7 +18,7 @@ Also the following steps were realized (if applies):
 - [ ] Open
 - [x] Done
 
-In case of an error due to linting run `black . --exclude docs/` and push your changes.
+In case of an error due to linting, run `black . --exclude docs/` and push your changes.
 Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.
 
 <sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,5 +19,6 @@ Also the following steps were realized (if applies):
 - [x] Done
 
 In case of an error due to linting run `black . --exclude docs/` and push your changes.
+Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.
 
 <sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Here is a template for new release sections
 ### Added
 -
 ### Changed
+- Divided check boxes in PR template into required checks and checks that do not apply to every PR, deleted the check box "Apply black" and added helpful notes (#266)
 -
 ### Removed
 -


### PR DESCRIPTION
Fix #Issue

**Changes proposed in this pull request**:
- Divided check boxes in PR template into required checks and checks that do not apply to every PR. 

We have decided to use the changelog from now on and also running tests with `EXECUTE_TESTS_ON=master pytest` is very important. Other checks depend on the changes in the PR - not everything has to be done for every PR. 
I deleted the check box "Apply black", as the CI build will fail anyways in case the code is not linted with black.

The PR template would look like the following now:
------------------------------------------------------------------------------


Fix #Issue

**Changes proposed in this pull request**:
- Your_changes

The following steps were realized, as well (required):
- [x] Update the CHANGELOG.md
- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>




