### PR TITLE
Install MVS with option "report" to install missing packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Here is a template for new release sections
 - Bug fix `fixcosts.csv` in test data (#263)
 - Bug fix in setup.py (#263)
 - Bug in calculation of the self-consumption was fixed (#261)
+- Hot fix: install MVS with option `[report]` to install missing packages (#270) 
 
 ## [0.0.1] - 2021-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Here is a template for new release sections
 -
 ```
 
+# Hot fixes
+- Hot fix: install MVS with option `[report]` to install missing packages (#270)
+- Hot fix: remove build for python 3.6 from `main.yml` github actions workflow (#270)
+
 ## [0.0.2] - 2021-03-24
 
 ### Added
@@ -33,7 +37,6 @@ Here is a template for new release sections
 - Bug fix `fixcosts.csv` in test data (#263)
 - Bug fix in setup.py (#263)
 - Bug in calculation of the self-consumption was fixed (#261)
-- Hot fix: install MVS with option `[report]` to install missing packages (#270) 
 
 ## [0.0.1] - 2021-03-22
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "scipy",
         "maya~=0.6.1",
         "workalendar < 7.0.0",
-        "multi_vector_simulator==0.5.5",
+        "multi_vector_simulator[report]==0.5.5",
         "greco_technologies @ git+https://github.com/greco-project/greco_technologies.git@dev#egg=greco_technologies-0",
         "cpvlib @ git+https://github.com/isi-ies-group/cpvlib.git@2020-11#egg=cpvlib-0",
         "mock>=3.0.5",


### PR DESCRIPTION
Fix #269

**Changes proposed in this pull request**:
- Install MVS with option "report" to install missing packages
- Removed python 3.6 from github actions builds as there was a error when installing `reverse_geocoder` of `[report]` option of MVS ` RuntimeError: Python version >= 3.7 required.` 

This is a hot fix for `master`. The error does not occur in build of dev as MVS simulations are not run there.

The process of hot fixes is to branch from master, only do the hot fix(es) and merge into master and dev then. 

The following steps were realized, as well (required):
- [x] Update the CHANGELOG.md
- [x] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting, run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
