### PR TITLE
update PV costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Here is a template for new release sections
 ### Removed
 -
 ### Fixed
--
+- fix costs parameters for new BOS and module costs (#273)
 # Hot fixes
 - Hot fix: install MVS with option `[report]` to install missing packages (#270)
 - Hot fix: remove build for python 3.6 from `main.yml` github actions workflow (#270)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Here is a template for new release sections
 -
 ### Fixed
 - fix PV costs parameters and PSI lifetime (#273)
+- fix number of houses to 20 (#273)
 # Hot fixes
 - Hot fix: install MVS with option `[report]` to install missing packages (#270)
 - Hot fix: remove build for python 3.6 from `main.yml` github actions workflow (#270)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Here is a template for new release sections
 -
 ### Fixed
 - fix PV costs parameters and PSI lifetime (#273)
-- fix number of houses to 20 (#273)
+- fix number of houses to 20 (8 flats per storey makes 40 flats per house with 5 storeys, makes 800 in total (and 480 for 3 storeys)) (#273)
 # Hot fixes
 - Hot fix: install MVS with option `[report]` to install missing packages (#270)
 - Hot fix: remove build for python 3.6 from `main.yml` github actions workflow (#270)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Here is a template for new release sections
 ### Removed
 -
 ### Fixed
-- fix costs parameters for new BOS and module costs (#273)
+- fix PV costs parameters and PSI lifetime (#273)
 # Hot fixes
 - Hot fix: install MVS with option `[report]` to install missing packages (#270)
 - Hot fix: remove build for python 3.6 from `main.yml` github actions workflow (#270)

--- a/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/energyProduction.csv
+++ b/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/energyProduction.csv
@@ -7,7 +7,7 @@ age_installed,year,0
 lifetime,year,25
 development_costs,currency,0
 specific_costs,currency/unit,934
-specific_costs_om,currency/unit/year,50
+specific_costs_om,currency/unit/year,20
 dispatch_price,currency/kWh,0
 outflow_direction,str,PV bus
 file_name,str,si_180_38_2014_52.52437_13.41053.csv

--- a/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/energyProduction.csv
+++ b/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/energyProduction.csv
@@ -6,7 +6,7 @@ installedCap,kWp,0
 age_installed,year,0
 lifetime,year,25
 development_costs,currency,0
-specific_costs,currency/unit,935
+specific_costs,currency/unit,934
 specific_costs_om,currency/unit/year,50
 dispatch_price,currency/kWh,0
 outflow_direction,str,PV bus

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProduction.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProduction.csv
@@ -6,7 +6,7 @@ installedCap,kWp,0
 age_installed,year,0
 lifetime,year,25
 development_costs,currency,0
-specific_costs,currency/unit,935
+specific_costs,currency/unit,934
 specific_costs_om,currency/unit/year,50
 dispatch_price,currency/kWh,0
 outflow_direction,str,PV bus

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProduction.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProduction.csv
@@ -7,7 +7,7 @@ age_installed,year,0
 lifetime,year,25
 development_costs,currency,0
 specific_costs,currency/unit,934
-specific_costs_om,currency/unit/year,50
+specific_costs_om,currency/unit/year,20
 dispatch_price,currency/kWh,0
 outflow_direction,str,PV bus
 file_name,str,si_180_31_2013_45.641603_5.875387.csv

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling_gas/csv_elements/energyProduction.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling_gas/csv_elements/energyProduction.csv
@@ -6,7 +6,7 @@ installedCap,kWp,0
 age_installed,year,0
 lifetime,year,25
 development_costs,currency,0
-specific_costs,currency/unit,935
+specific_costs,currency/unit,934
 specific_costs_om,currency/unit/year,50
 dispatch_price,currency/kWh,0
 outflow_direction,str,PV bus

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling_gas/csv_elements/energyProduction.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling_gas/csv_elements/energyProduction.csv
@@ -7,7 +7,7 @@ age_installed,year,0
 lifetime,year,25
 development_costs,currency,0
 specific_costs,currency/unit,934
-specific_costs_om,currency/unit/year,50
+specific_costs_om,currency/unit/year,20
 dispatch_price,currency/kWh,0
 outflow_direction,str,PV bus
 file_name,str,si_180_31_2013_45.641603_5.875387.csv

--- a/examples/example_user_inputs/pvcompare_inputs/building_parameters.csv
+++ b/examples/example_user_inputs/pvcompare_inputs/building_parameters.csv
@@ -1,6 +1,6 @@
 building parameter,value
 number of storeys,5
-number of houses,400
+number of houses,20
 population per storey,32
 total storey area,1232
 length south facade,56

--- a/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProduction.csv
+++ b/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProduction.csv
@@ -6,7 +6,7 @@ installedCap,kWp,0,0,0
 age_installed,year,0,0,0
 lifetime,year,25,25,20
 development_costs,currency,0,0,0
-specific_costs,currency/unit,935,1033,836
+specific_costs,currency/unit,934,1019,813
 specific_costs_om,currency/unit/year,50,27,35
 dispatch_price,currency/kWh,0,0,0
 outflow_direction,str,PV bus,PV bus,PV bus

--- a/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProduction.csv
+++ b/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProduction.csv
@@ -4,10 +4,10 @@ optimizeCap,bool,True,True,True
 maximumCap,None or float,,,
 installedCap,kWp,0,0,0
 age_installed,year,0,0,0
-lifetime,year,25,25,20
+lifetime,year,25,25,25
 development_costs,currency,0,0,0
 specific_costs,currency/unit,934,1019,813
-specific_costs_om,currency/unit/year,50,27,35
+specific_costs_om,currency/unit/year,20,15,17
 dispatch_price,currency/kWh,0,0,0
 outflow_direction,str,PV bus,PV bus,PV bus
 file_name,str,,,

--- a/pvcompare/data/user_inputs_collection/pvcompare_inputs/building_parameters.csv
+++ b/pvcompare/data/user_inputs_collection/pvcompare_inputs/building_parameters.csv
@@ -1,5 +1,6 @@
 building parameter,value
 number of storeys,5
+number of houses,20
 population per storey,32
 total storey area,1232
 length south facade,56

--- a/pvcompare/plots.py
+++ b/pvcompare/plots.py
@@ -616,21 +616,24 @@ def plot_kpi_loop(
                     )
                 counter += 1
             else:
-                df.plot(
-                    x="step",
-                    y=i,
-                    style=".",
-                    ax=ax,
-                    label=key,
-                    legend=False,
-                    sharex=True,
-                    xticks=df.step,
-                )
-                ax.set_ylabel(y_title[i])
-                ax.set_xlabel(variable_name)
-                ax.get_yaxis().set_label_coords(-0.13, 0.5)
-                ax.set_xticks(df.step)
-                ax.set_xlim(ax.get_xlim()[0] - 0.5, ax.get_xlim()[1] + 0.5)
+                try:
+                    df.plot(
+                        x="step",
+                        y=i,
+                        style=".",
+                        ax=ax,
+                        label=key,
+                        legend=False,
+                        sharex=True,
+                        xticks=df.step,
+                    )
+                    ax.set_ylabel(y_title[i])
+                    ax.set_xlabel(variable_name)
+                    ax.get_yaxis().set_label_coords(-0.13, 0.5)
+                    ax.set_xticks(df.step)
+                    ax.set_xlim(ax.get_xlim()[0] - 0.5, ax.get_xlim()[1] + 0.5)
+                except:
+                    pass
 
     plt.tight_layout(rect=(0.04, 0.13, 1, 1))
 


### PR DESCRIPTION
Fix #xxx

**Changes proposed in this pull request**:
- the BOS component costs taken from 2014 are extrapolated for 2019 and  50% higher BOS costs are added because we look at a rooftop system (see working paper section 1a))
- this results in higher BOS costs
- the module prices are lowered (after more research). For more information see working paper.
- the lifetime of PSI is set to 25
- OM costs are lowered (see working paper)
- fix number of houses to 20 ( 8 flats per storey makes 40 flats per house with 5 storeys, makes 800 in total (and 480 for 3 storeys))

The following steps were realized, as well (required):
- [x] Update the CHANGELOG.md
- [x] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting, run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
