### PR TITLE
RTD requirements in setup.py and readthedocs.yml added

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,25 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Required
+version: 2
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+#formats:
+#  - pdf
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+    - method: setuptools
+      path: package

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,4 +22,4 @@ python:
       extra_requirements:
         - docs
     - method: setuptools
-      path: package
+      path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ Here is a template for new release sections
 ## [unreleased]
 
 ### Added
--
+- Add config file for RTD `readthedocs.yml` (#276)
+
 ### Changed
--
+- Move docs requirements from `docs/docs_requirements.txt ` to `setup.py` - now installed e.g. by `pip install -e .[dev, docs]` (#276)
+
 ### Removed
 -
 ### Fixed

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -1,2 +1,0 @@
-Sphinx >= '1.4.3'
-sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,10 @@ setup(
             "black==19.10b0",
             "coverage==5.0.3",
             "coveralls==1.11.0",
+        ]
+        "docs": [
             "sphinx_rtd_theme",
+            "Sphinx>=1.4.3"
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
             "black==19.10b0",
             "coverage==5.0.3",
             "coveralls==1.11.0",
-        ]
+        ],
         "docs": [
             "sphinx_rtd_theme",
             "Sphinx>=1.4.3"

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,6 @@ setup(
             "coverage==5.0.3",
             "coveralls==1.11.0",
         ],
-        "docs": [
-            "sphinx_rtd_theme",
-            "Sphinx>=1.4.3"
-        ]
+        "docs": ["sphinx_rtd_theme", "Sphinx>=1.4.3"],
     },
 )


### PR DESCRIPTION
Fix #Issue

**Changes proposed in this pull request**:
- Move docs requirements from `docs/docs_requirements.txt ` to `setup.py` - now installed e.g. by `pip install -e .[dev, docs]`
- Add config file for RTD `readthedocs.yml`

The following steps were realized, as well (required):
- [x] Update the CHANGELOG.md
- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting, run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
