### PR TITLE
Feature/test examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Here is a template for new release sections
 ## [unreleased]
 
 ### Added
--
+- Tests have been added which check if the examples of pvcompare run with exit code 0 (#284)
 ### Changed
 - The inlet temperatures of the heat pump and the stratified thermal storage have been revised in the pvcompare input parameters, adapting them in order to fit typical temperatures of the heating system. Also the pvcompare input parameters of the stratified thermal storage have been revised (#272)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -54,23 +54,28 @@ class TestCalculateCopsAndEers:
             scenario_name, scenario_name + "_test_run_through"
         )
 
-        # Open D1_model_components.py in write modus and save the version
-        # with commented out fixed losses
+        # Open example file in write modus and save the version
+        # with changed scenrario name
         elec_sector_modified = open(self.elec_sector_path, "w")
         elec_sector_modified.write(elec_sector_modified_string)
         elec_sector_modified.close()
 
+        # Run example with os.system("python <filename_of_example.py>") and check if
+        # result is 0. In this case the script runs through with exit code 0
+        # In case the example errors out with exit code 1
+        # os.system("python <filename_of_example.py>") returns 256:
+        # 256 in 16 bits -> binary number: 00000001 00000000 -> 1
         if os.system("python " + self.elec_sector_path) == 0:
             exit_code = 0
 
         assert exit_code == 0
 
-        # Revert changes made in D1_model_components.py
+        # Revert changes made in the example file
         elec_sector_modified = open(self.elec_sector_path, "w")
         elec_sector_modified.write(elec_sector)
         elec_sector_modified.close()
 
-        # Delete example output of tests
+        # Delete example output directory of this test
         dir_name = os.path.join(
             self.outputs_directory, scenario_name + "_test_run_through",
         )
@@ -97,23 +102,28 @@ class TestCalculateCopsAndEers:
             scenario_name, scenario_name + "_test_run_through"
         )
 
-        # Open D1_model_components.py in write modus and save the version
-        # with commented out fixed losses
+        # Open example file in write modus and save the version
+        # with changed scenrario name
         coupled_sector_modified = open(self.coupled_sector_path, "w")
         coupled_sector_modified.write(coupled_sector_modified_string)
         coupled_sector_modified.close()
 
+        # Run example with os.system("python <filename_of_example.py>") and check if
+        # result is 0. In this case the script runs through with exit code 0
+        # In case the example errors out with exit code 1
+        # os.system("python <filename_of_example.py>") returns 256:
+        # 256 in 16 bits -> binary number: 00000001 00000000 -> 1
         if os.system("python " + self.coupled_sector_path) == 0:
             exit_code = 0
 
         assert exit_code == 0
 
-        # Revert changes made in D1_model_components.py
+        # Revert changes made in the example file
         coupled_sector_modified = open(self.coupled_sector_path, "w")
         coupled_sector_modified.write(coupled_sector)
         coupled_sector_modified.close()
 
-        # Delete example output of tests
+        # Delete example output directory of this test
         dir_name = os.path.join(
             self.outputs_directory, scenario_name + "_test_run_through",
         )
@@ -140,23 +150,28 @@ class TestCalculateCopsAndEers:
             scenario_name, scenario_name + "_test_run_through"
         )
 
-        # Open D1_model_components.py in write modus and save the version
-        # with commented out fixed losses
+        # Open example file in write modus and save the version
+        # with changed scenrario name
         coupled_sector_gas_modified = open(self.coupled_sector_gas_path, "w")
         coupled_sector_gas_modified.write(coupled_sector_gas_modified_string)
         coupled_sector_gas_modified.close()
 
+        # Run example with os.system("python <filename_of_example.py>") and check if
+        # result is 0. In this case the script runs through with exit code 0
+        # In case the example errors out with exit code 1
+        # os.system("python <filename_of_example.py>") returns 256:
+        # 256 in 16 bits -> binary number: 00000001 00000000 -> 1
         if os.system("python " + self.coupled_sector_gas_path) == 0:
             exit_code = 0
 
         assert exit_code == 0
 
-        # Revert changes made in D1_model_components.py
+        # Revert changes made in the example file
         coupled_sector_gas_modified = open(self.coupled_sector_gas_path, "w")
         coupled_sector_gas_modified.write(coupled_sector_gas)
         coupled_sector_gas_modified.close()
 
-        # Delete example output of tests
+        # Delete example output directory of this test
         dir_name = os.path.join(
             self.outputs_directory, scenario_name + "_test_run_through",
         )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -89,7 +89,9 @@ class TestExamples:
         if os.system("python " + self.elec_sector_path) == 0:
             exit_code = 0
 
-        assert exit_code == 0
+        assert (
+            exit_code == 0
+        ), f"The example run_pvcompare_example_electricity_sector.py exited with exit code {exit_code}."
 
         # Revert changes made in the example file
         elec_sector_modified = open(self.elec_sector_path, "w")
@@ -133,7 +135,9 @@ class TestExamples:
         if os.system("python " + self.coupled_sector_path) == 0:
             exit_code = 0
 
-        assert exit_code == 0
+        assert (
+            exit_code == 0
+        ), f"The example run_pvcompare_example_sector_coupling.py exited with exit code {exit_code}."
 
         # Revert changes made in the example file
         coupled_sector_modified = open(self.coupled_sector_path, "w")
@@ -177,7 +181,9 @@ class TestExamples:
         if os.system("python " + self.coupled_sector_gas_path) == 0:
             exit_code = 0
 
-        assert exit_code == 0
+        assert (
+            exit_code == 0
+        ), f"The example run_pvcompare_example_sector_coupling_gas.py exited with exit code {exit_code}."
 
         # Revert changes made in the example file
         coupled_sector_gas_modified = open(self.coupled_sector_gas_path, "w")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -99,11 +99,11 @@ class TestExamples:
         # Delete example output directory of this test
         TestExamples.teardown_method(self)
 
-    # # this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
-    # # alone is called
+    # this ensures that the test is only run if explicitly executed, i.e. not when the `pytest` command
+    # alone is called
     @pytest.mark.skipif(
         EXECUTE_TESTS_ON not in (TESTS_ON_MASTER),
-        reason="Benchmark test deactivated, set env variable "
+        reason="Test deactivated, set env variable "
         "EXECUTE_TESTS_ON to 'master' to run this test",
     )
     @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
@@ -143,11 +143,11 @@ class TestExamples:
         # Delete example output directory of this test
         TestExamples.teardown_method(self)
 
-    # # this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
-    # # alone is called
+    # this ensures that the test is only run if explicitly executed, i.e. not when the `pytest` command
+    # alone is called
     @pytest.mark.skipif(
         EXECUTE_TESTS_ON not in (TESTS_ON_MASTER),
-        reason="Benchmark test deactivated, set env variable "
+        reason="Test deactivated, set env variable "
         "EXECUTE_TESTS_ON to 'master' to run this test",
     )
     @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -20,19 +20,40 @@ EXECUTE_TESTS_ON = os.environ.get("EXECUTE_TESTS_ON", "skip")
 TESTS_ON_MASTER = "master"
 
 
-class TestCalculateCopsAndEers:
+class TestExamples:
     @classmethod
     def setup_class(self):
         self.outputs_directory = constants.EXAMPLE_OUTPUTS_DIRECTORY
         self.elec_sector_path = os.path.join(
             constants.EXAMPLE_DIRECTORY, "run_pvcompare_example_electricity_sector.py"
         )
+        self.elec_sector_scenario_name = "Scenario_example_electricity_sector"
+
         self.coupled_sector_path = os.path.join(
             constants.EXAMPLE_DIRECTORY, "run_pvcompare_example_sector_coupling.py"
         )
+        self.coupled_sector_scenario_name = "Scenario_example_sector_coupling"
+
         self.coupled_sector_gas_path = os.path.join(
             constants.EXAMPLE_DIRECTORY, "run_pvcompare_example_sector_coupling_gas.py"
         )
+        self.coupled_sector_gas_scenario_name = (
+            "Scenario_example_sector_coupling_gas_heating"
+        )
+
+    def teardown_method(self):
+        scenarios = [
+            self.elec_sector_scenario_name,
+            self.coupled_sector_scenario_name,
+            self.coupled_sector_gas_scenario_name,
+        ]
+        # Delete example output directories of all tests they existing
+        for scenario in scenarios:
+            dir_name = os.path.join(
+                self.outputs_directory, scenario + "_test_run_through",
+            )
+            if os.path.exists(dir_name):
+                shutil.rmtree(dir_name, ignore_errors=True)
 
     # this ensures that the test is only run if explicitly executed, i.e. not when the `pytest` command
     # alone is called
@@ -44,7 +65,7 @@ class TestCalculateCopsAndEers:
     @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
     def test_run_pvcompare_example_electricity_sector(self, margs):
         exit_code = 1
-        scenario_name = "Scenario_example_electricity_sector"
+        scenario_name = self.elec_sector_scenario_name
         # Read run_pvcompare_example_electricity_sector.py
         elec_sector = open(self.elec_sector_path).read()
 
@@ -76,11 +97,7 @@ class TestCalculateCopsAndEers:
         elec_sector_modified.close()
 
         # Delete example output directory of this test
-        dir_name = os.path.join(
-            self.outputs_directory, scenario_name + "_test_run_through",
-        )
-        if os.path.exists(dir_name):
-            shutil.rmtree(dir_name, ignore_errors=True)
+        TestExamples.teardown_method(self)
 
     # # this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
     # # alone is called
@@ -92,7 +109,7 @@ class TestCalculateCopsAndEers:
     @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
     def test_run_pvcompare_example_sector_coupling(self, margs):
         exit_code = 1
-        scenario_name = "Scenario_example_sector_coupling"
+        scenario_name = self.coupled_sector_scenario_name
         # Read run_pvcompare_example_sector_coupling.py
         coupled_sector = open(self.coupled_sector_path).read()
 
@@ -124,11 +141,7 @@ class TestCalculateCopsAndEers:
         coupled_sector_modified.close()
 
         # Delete example output directory of this test
-        dir_name = os.path.join(
-            self.outputs_directory, scenario_name + "_test_run_through",
-        )
-        if os.path.exists(dir_name):
-            shutil.rmtree(dir_name, ignore_errors=True)
+        TestExamples.teardown_method(self)
 
     # # this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
     # # alone is called
@@ -140,7 +153,7 @@ class TestCalculateCopsAndEers:
     @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
     def test_run_pvcompare_example_sector_coupling_gas(self, margs):
         exit_code = 1
-        scenario_name = "Scenario_example_sector_coupling_gas_heating"
+        scenario_name = self.coupled_sector_gas_scenario_name
         # Read run_pvcompare_example_sector_coupling_gas.py
         coupled_sector_gas = open(self.coupled_sector_gas_path).read()
 
@@ -172,8 +185,4 @@ class TestCalculateCopsAndEers:
         coupled_sector_gas_modified.close()
 
         # Delete example output directory of this test
-        dir_name = os.path.join(
-            self.outputs_directory, scenario_name + "_test_run_through",
-        )
-        if os.path.exists(dir_name):
-            shutil.rmtree(dir_name, ignore_errors=True)
+        TestExamples.teardown_method(self)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,164 @@
+"""
+run these tests with `pytest tests/name_of_test_module.py` or `pytest tests`
+or simply `pytest` pytest will look for all files starting with "test_" and run
+all functions within this file starting with "test_". For basic example of
+tests you can look at our workshop
+https://github.com/rl-institut/workshop/tree/master/test-driven-development.
+Otherwise https://docs.pytest.org/en/latest/ and
+https://docs.python.org/3/library/unittest.html are also good support.
+
+These tests check if the examples of pvcompare run through
+"""
+import pytest
+import argparse
+import mock
+import os
+import pvcompare.constants as constants
+import shutil
+
+EXECUTE_TESTS_ON = os.environ.get("EXECUTE_TESTS_ON", "skip")
+TESTS_ON_MASTER = "master"
+
+
+class TestCalculateCopsAndEers:
+    @classmethod
+    def setup_class(self):
+        self.outputs_directory = constants.EXAMPLE_OUTPUTS_DIRECTORY
+        self.elec_sector_path = os.path.join(
+            constants.EXAMPLE_DIRECTORY, "run_pvcompare_example_electricity_sector.py"
+        )
+        self.coupled_sector_path = os.path.join(
+            constants.EXAMPLE_DIRECTORY, "run_pvcompare_example_sector_coupling.py"
+        )
+        self.coupled_sector_gas_path = os.path.join(
+            constants.EXAMPLE_DIRECTORY, "run_pvcompare_example_sector_coupling_gas.py"
+        )
+
+    # # this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
+    # # alone is called
+    @pytest.mark.skipif(
+        EXECUTE_TESTS_ON not in (TESTS_ON_MASTER),
+        reason="Benchmark test deactivated, set env variable "
+        "EXECUTE_TESTS_ON to 'master' to run this test",
+    )
+    @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
+    def test_run_pvcompare_example_electricity_sector(self, margs):
+        exit_code = 1
+        scenario_name = "Scenario_example_electricity_sector"
+        # Read run_pvcompare_example_electricity_sector.py
+        elec_sector = open(self.elec_sector_path).read()
+
+        # Modify the name of the scenario to ensure it will run through for the test
+        # if the user already has it in the examples output folder
+        elec_sector_modified_string = elec_sector.replace(
+            scenario_name, scenario_name + "_test_run_through"
+        )
+
+        # Open D1_model_components.py in write modus and save the version
+        # with commented out fixed losses
+        elec_sector_modified = open(self.elec_sector_path, "w")
+        elec_sector_modified.write(elec_sector_modified_string)
+        elec_sector_modified.close()
+
+        if os.system("python " + self.elec_sector_path) == 0:
+            exit_code = 0
+
+        assert exit_code == 0
+
+        # Revert changes made in D1_model_components.py
+        elec_sector_modified = open(self.elec_sector_path, "w")
+        elec_sector_modified.write(elec_sector)
+        elec_sector_modified.close()
+
+        # Delete example output of tests
+        dir_name = os.path.join(
+            self.outputs_directory, scenario_name + "_test_run_through",
+        )
+        if os.path.exists(dir_name):
+            shutil.rmtree(dir_name, ignore_errors=True)
+
+    # # this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
+    # # alone is called
+    @pytest.mark.skipif(
+        EXECUTE_TESTS_ON not in (TESTS_ON_MASTER),
+        reason="Benchmark test deactivated, set env variable "
+        "EXECUTE_TESTS_ON to 'master' to run this test",
+    )
+    @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
+    def test_run_pvcompare_example_sector_coupling(self, margs):
+        exit_code = 1
+        scenario_name = "Scenario_example_sector_coupling"
+        # Read run_pvcompare_example_sector_coupling.py
+        coupled_sector = open(self.coupled_sector_path).read()
+
+        # Modify the name of the scenario to ensure it will run through for the test
+        # if the user already has it in the examples output folder
+        coupled_sector_modified_string = coupled_sector.replace(
+            scenario_name, scenario_name + "_test_run_through"
+        )
+
+        # Open D1_model_components.py in write modus and save the version
+        # with commented out fixed losses
+        coupled_sector_modified = open(self.coupled_sector_path, "w")
+        coupled_sector_modified.write(coupled_sector_modified_string)
+        coupled_sector_modified.close()
+
+        if os.system("python " + self.coupled_sector_path) == 0:
+            exit_code = 0
+
+        assert exit_code == 0
+
+        # Revert changes made in D1_model_components.py
+        coupled_sector_modified = open(self.coupled_sector_path, "w")
+        coupled_sector_modified.write(coupled_sector)
+        coupled_sector_modified.close()
+
+        # Delete example output of tests
+        dir_name = os.path.join(
+            self.outputs_directory, scenario_name + "_test_run_through",
+        )
+        if os.path.exists(dir_name):
+            shutil.rmtree(dir_name, ignore_errors=True)
+
+    # # this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
+    # # alone is called
+    @pytest.mark.skipif(
+        EXECUTE_TESTS_ON not in (TESTS_ON_MASTER),
+        reason="Benchmark test deactivated, set env variable "
+        "EXECUTE_TESTS_ON to 'master' to run this test",
+    )
+    @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
+    def test_run_pvcompare_example_sector_coupling_gas(self, margs):
+        exit_code = 1
+        scenario_name = "Scenario_example_sector_coupling_gas_heating"
+        # Read run_pvcompare_example_sector_coupling_gas.py
+        coupled_sector_gas = open(self.coupled_sector_gas_path).read()
+
+        # Modify the name of the scenario to ensure it will run through for the test
+        # if the user already has it in the examples output folder
+        coupled_sector_gas_modified_string = coupled_sector_gas.replace(
+            scenario_name, scenario_name + "_test_run_through"
+        )
+
+        # Open D1_model_components.py in write modus and save the version
+        # with commented out fixed losses
+        coupled_sector_gas_modified = open(self.coupled_sector_gas_path, "w")
+        coupled_sector_gas_modified.write(coupled_sector_gas_modified_string)
+        coupled_sector_gas_modified.close()
+
+        if os.system("python " + self.coupled_sector_gas_path) == 0:
+            exit_code = 0
+
+        assert exit_code == 0
+
+        # Revert changes made in D1_model_components.py
+        coupled_sector_gas_modified = open(self.coupled_sector_gas_path, "w")
+        coupled_sector_gas_modified.write(coupled_sector_gas)
+        coupled_sector_gas_modified.close()
+
+        # Delete example output of tests
+        dir_name = os.path.join(
+            self.outputs_directory, scenario_name + "_test_run_through",
+        )
+        if os.path.exists(dir_name):
+            shutil.rmtree(dir_name, ignore_errors=True)


### PR DESCRIPTION
Fix Issue https://github.com/greco-project/pvcompare/issues/228

With this PR tests are added which check if the examples in pvcompare run.

Running with `exit code == 0` leads to:

```
os.system("python example_to_be_tested.py") == 0
```


The following steps were realized, as well (required):
- [x] Update the CHANGELOG.md
- [x] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting, run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
