### PR TITLE
Fix/sim params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Here is a template for new release sections
 - Move coverage badge of `coveralls.io` from deprecated to valid section in `README.rst` (#289)
 - Update code documentation in RTD: add missing functions and modules and delete outdated ones (#287)
 - Update RTD's section `Electricity and heat demand modeling` and `Heat pump and thermal storage modelling` in `model_assumptions.rst` (#291)
+- The parameters `inflow_direction` and `outflow_direction` of the gas plant have been changed from `Heat bus` to `Gas bus` in `energyProviders.csv` (#299)
+- The parameter `energyVector` of the gas plant has been changed from `Heat` to `Gas` in `energyProviders.csv` (#299)
+- All parameters in `fixcost.csv` have been set to zero except for the lifetime, which has been set to one for all in order to avoid ZeroDivisionError (#299)
 
 ### Removed
 -

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -205,13 +205,13 @@ energyProviders.csv
     5. **optimizeCap**: bool, True (for all of the components)
     6. **outflow_direction**: str,
         a. **Electricity grid**: Electricity
-        b. **Gas plant**: Heat bus
+        b. **Gas plant**: Gas bus
     7. **peak_demand_pricing**: currency/kW, 0 (for all of the components)
     8. **peak_demand_pricing_period**: 	times per year (1,2,3,4,6,12), 1 (for all of the components)
     9. **type_oemof**: str, source (for all of the components)
     10. **energyVector**: str,
         a. **Electricity grid**: Electricity
-        b. **Gas plant**: Heat
+        b. **Gas plant**: Gas
     11. **emission factor**: kgCO2eq/kWh
         a. **Electricity grid**: 0.338
         b. **Gas plant**: 0.2 (Obtained from `Quaschning 06/2015 <https://www.volker-quaschning.de/datserv/CO2-spez/index_e.php>`_.)

--- a/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/fixcost.csv
+++ b/examples/example_user_inputs/mvs_inputs_electricity_sector/csv_elements/fixcost.csv
@@ -1,6 +1,6 @@
 ,unit,distribution_grid,engineering,operation
-age_installed,year,10,0,0
-lifetime,year,30,20,20
+age_installed,year,0,0,0
+lifetime,year,1,1,1
 development_costs,currency,0.0,0,0
 specific_costs,currency,0.0,0,0
-specific_costs_om,currency/year,0,0,4600
+specific_costs_om,currency/year,0,0,0

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/fixcost.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling/csv_elements/fixcost.csv
@@ -1,6 +1,6 @@
 ,unit,distribution_grid,engineering,operation
-age_installed,year,10,0,0
-lifetime,year,30,20,20
+age_installed,year,0,0,0
+lifetime,year,1,1,1
 development_costs,currency,0.0,0,0
 specific_costs,currency,0.0,0,0
-specific_costs_om,currency/year,0,0,4600
+specific_costs_om,currency/year,0,0,0

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling_gas/csv_elements/energyProviders.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling_gas/csv_elements/energyProviders.csv
@@ -8,6 +8,6 @@ peak_demand_pricing_period,"times per year (1,2,3,4,6,12)",1,1
 renewable_share,factor,0.1,0
 inflow_direction,str,Electricity bus,Gas bus
 outflow_direction,str,Electricity bus,Gas bus
-energyVector,str,Electricity,Heat
+energyVector,str,Electricity,Gas
 type_oemof,str,source,source
 emission_factor,kgCO2eq/kWh,0.338,0.2

--- a/examples/example_user_inputs/mvs_inputs_sector_coupling_gas/csv_elements/fixcost.csv
+++ b/examples/example_user_inputs/mvs_inputs_sector_coupling_gas/csv_elements/fixcost.csv
@@ -1,6 +1,6 @@
 ,unit,distribution_grid,engineering,operation
-age_installed,year,10,0,0
-lifetime,year,30,20,20
+age_installed,year,0,0,0
+lifetime,year,1,1,1
 development_costs,currency,0.0,0,0
 specific_costs,currency,0.0,0,0
-specific_costs_om,currency/year,0,0,4600
+specific_costs_om,currency/year,0,0,0

--- a/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProviders.csv
+++ b/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/energyProviders.csv
@@ -8,6 +8,6 @@ peak_demand_pricing_period,"times per year (1,2,3,4,6,12)",1,1,1
 renewable_share,factor,0.1,0,0
 inflow_direction,str,Electricity bus,Gas bus,Gas bus
 outflow_direction,str,Electricity bus,Gas bus,Gas bus
-energyVector,str,Electricity,Heat,Heat
+energyVector,str,Electricity,Gas,Gas
 type_oemof,str,source,source,source
 emission_factor,kgCO2eq/kWh,0.338,0.2,0.2

--- a/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/fixcost.csv
+++ b/pvcompare/data/user_inputs_collection/mvs_inputs/csv_elements/fixcost.csv
@@ -1,6 +1,6 @@
 ,unit,distribution_grid,engineering,operation
 age_installed,year,0,0,0
-lifetime,year,0,0,0
+lifetime,year,1,1,1
 development_costs,currency,0.0,0,0
 specific_costs_om,currency/year,0,0,0
 specific_costs,currency,0.0,0,0

--- a/tests/data/user_inputs/mvs_inputs/csv_elements/energyProviders.csv
+++ b/tests/data/user_inputs/mvs_inputs/csv_elements/energyProviders.csv
@@ -6,8 +6,8 @@ feedin_tariff,currency/kWh,0.05,0
 peak_demand_pricing,currency/kW,0,0
 peak_demand_pricing_period,"times per year (1,2,3,4,6,12)",1,1
 renewable_share,factor,0.184,0
-inflow_direction,str,Electricity bus,Heat bus
-outflow_direction,str,Electricity bus,Heat bus
-energyVector,str,Electricity,Heat
+inflow_direction,str,Electricity bus,Gas bus
+outflow_direction,str,Electricity bus,Gas bus
+energyVector,str,Electricity,Gas
 type_oemof,str,source,source
 emission_factor,kgCO2eq/kWh,207,500

--- a/tests/data/user_inputs/mvs_inputs/csv_elements/fixcost.csv
+++ b/tests/data/user_inputs/mvs_inputs/csv_elements/fixcost.csv
@@ -1,6 +1,6 @@
 ,unit,distribution_grid,engineering,operation
-age_installed,year,10,0,0
-lifetime,year,30,20,20
+age_installed,year,0,0,0
+lifetime,year,1,1,1
 development_costs,currency,0.0,0,0
 specific_costs,currency,0.0,0,0
-specific_costs_om,currency/year,0,0,4600
+specific_costs_om,currency/year,0,0,0

--- a/tests/data/user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProviders.csv
+++ b/tests/data/user_inputs/mvs_inputs_sector_coupling/csv_elements/energyProviders.csv
@@ -6,8 +6,8 @@ feedin_tariff,currency/kWh,0.05,0
 peak_demand_pricing,currency/kW,0,0
 peak_demand_pricing_period,"times per year (1,2,3,4,6,12)",1,1
 renewable_share,factor,0.184,0
-inflow_direction,str,Electricity bus,Heat bus
-outflow_direction,str,Electricity bus,Heat bus
-energyVector,str,Electricity,Heat
+inflow_direction,str,Electricity bus,Gas bus
+outflow_direction,str,Electricity bus,Gas bus
+energyVector,str,Electricity,Gas
 type_oemof,str,source,source
 emission_factor,kgCO2eq/kWh,0.338,0.2

--- a/tests/data/user_inputs/mvs_inputs_sector_coupling/csv_elements/fixcost.csv
+++ b/tests/data/user_inputs/mvs_inputs_sector_coupling/csv_elements/fixcost.csv
@@ -1,6 +1,6 @@
 ,unit,distribution_grid,engineering,operation
-age_installed,year,10,0,0
-lifetime,year,30,20,20
+age_installed,year,0,0,0
+lifetime,year,1,1,1
 development_costs,currency,0.0,0,0
-specific_costs_om,currency/year,0,0,4600
+specific_costs_om,currency/year,0,0,0
 specific_costs,currency,0.0,0,0

--- a/tests/data/user_inputs_collection/mvs_inputs/csv_elements/energyProviders.csv
+++ b/tests/data/user_inputs_collection/mvs_inputs/csv_elements/energyProviders.csv
@@ -8,6 +8,6 @@ peak_demand_pricing_period,"times per year (1,2,3,4,6,12)",1,1,1
 renewable_share,factor,0.1,0,0
 inflow_direction,str,Electricity bus,Gas bus,Gas bus
 outflow_direction,str,Electricity bus,Gas bus,Gas bus
-energyVector,str,Electricity,Heat,Heat
+energyVector,str,Electricity,Gas,Gas
 type_oemof,str,source,source,source
 emission_factor,kgCO2eq/kWh,0.338,0.2,0.2

--- a/tests/data/user_inputs_collection/mvs_inputs/csv_elements/fixcost.csv
+++ b/tests/data/user_inputs_collection/mvs_inputs/csv_elements/fixcost.csv
@@ -1,6 +1,6 @@
 ,unit,distribution_grid,engineering,operation
 age_installed,year,0,0,0
-lifetime,year,0,0,0
+lifetime,year,1,1,1
 development_costs,currency,0.0,0,0
 specific_costs_om,currency/year,0,0,0
 specific_costs,currency,0.0,0,0

--- a/tests/data_test_main/user_inputs/mvs_inputs/csv_elements/fixcost.csv
+++ b/tests/data_test_main/user_inputs/mvs_inputs/csv_elements/fixcost.csv
@@ -1,6 +1,6 @@
 ,unit,distribution_grid,engineering,operation
-age_installed,year,10,0,0
-lifetime,year,30,20,20
+age_installed,year,0,0,0
+lifetime,year,1,1,1
 development_costs,currency,0.0,0,0
 specific_costs,currency,0.0,0,0
-specific_costs_om,currency/year,0,0,4600
+specific_costs_om,currency/year,0,0,0


### PR DESCRIPTION
With this PR the following parameters are adapted for:

- Gas provider in energyProviders.csv ( `inflow_direction` and  `outflow_direction` from `Heat bus` to `Gas bus` and `energyVector` from `Heat` to `Gas`)
- fixcost.csv (`age_installed`, `development_costs`, `specific_costs_om` and `specific_costs` are neglected in the simulations and hence set to `0`.  As mentioned by @SabineHaas in PR https://github.com/greco-project/pvcompare/pull/251, setting lifetime to `0` lead to a ZeroDivisionError. To give a hint that the lifetime has been set without higher intentions regarding the value, I chose a lifetime of `1` for all three components)


The following steps were realized, as well (required):
- [x] Update the CHANGELOG.md
- [x] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting, run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
