### PR TITLE
Fix GitHub actions for release branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,11 @@ jobs:
         run: |
           echo "EXECUTE_TESTS_ON=master" >> $GITHUB_ENV
 
+      - name: Set env for release branches
+          if: endsWith(github.ref, 'release-*')
+          run: |
+            echo "EXECUTE_TESTS_ON=master" >> $GITHUB_ENV
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,14 @@
 name: CI
 
 # Controls when the action will run. # Triggers the workflow on push or pull request
-# events; push events only for dev and master branch
+# events; push events only for dev, master and release branches
 on:
   push:
     branches:
       - dev
       - master
+      - release
+      - 'release-*'
 
   pull_request:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Set env for dev branch
-        if: endsWith(github.ref, '/develop')
+        if: endsWith(github.ref, '/dev')
         run: |
           echo "EXECUTE_TESTS_ON=dev" >> $GITHUB_ENV
           


### PR DESCRIPTION
Address #297

Note that this fix can only be tested with the next release, see todo in #304

**Changes proposed in this pull request**:
- In github actions workflow, add release branches to push events and correct name of `dev` branch
- In github actions workflow, set `EXECUTE_TEST_ON` to `"master"` for release branches

The following steps were realized, as well (required):
- [ ] Update the CHANGELOG.md
- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting, run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
