### PR TITLE
Add binder badge to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|badge_docs| |badge_CI| |badge_coverage|
+|badge_docs| |badge_CI| |badge_coverage| |binder|
 
 Deprecated: |badge_travis| 
 
@@ -17,6 +17,8 @@ Deprecated: |badge_travis|
 .. |badge_travis| image:: https://travis-ci.com/greco-project/pvcompare.svg?branch=dev
     :target: https://travis-ci.com/greco-project/pvcompare
 
+.. |binder| image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/greco-project/pvcompare/dev?filepath=https%3A%2F%2Fgithub.com%2Fgreco-project%2Fpvcompare%2Ftree%2Fdev%2Fexamples
 
 pvcompare
 ~~~~~~~~~


### PR DESCRIPTION
Address #161

**Changes proposed in this pull request**:
- Add badge of binder to README, tried to launched binder with https://mybinder.org
- [ ] requirements have to be defined in a different way...

The following steps were realized, as well (required):
- [ ] Update the CHANGELOG.md
- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting, run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
