### PR TITLE
Adapt docstring of main.py

### DIFF
--- a/pvcompare/main.py
+++ b/pvcompare/main.py
@@ -46,9 +46,10 @@ def apply_pvcompare(
     Runs the main functionalities of pvcompare.
 
     Loads weather data for the given year and location, calculates pv feed-in time
-    series, as well as the nominal values /installation capacities based on the building
-    parameters. Additionally, COPs are calculated if a heat pump is added to the energy
-    system.
+    series, as well as the nominal values / installation capacities based on the parameters
+    in 'building_parameters.csv' in `user_inputs_pvcompare_directory`. Additionally,
+    COPs are calculated if a heat pump is added to the energy system and precalculations
+    for a stratified thermal storage are done if it is added to the energy system.
 
     Parameters
     ----------
@@ -88,50 +89,62 @@ def apply_pvcompare(
         Default: True. If True, the following grid parameters are inserted into the
         mvs input csv'S automatically: electricity price, feed-in tariff,
         CO2 emissions, renewable share, gas price
+        Default: True.
     overwrite_pv_parameters: bool
         Default: True. If true, the pv components in energyProduction.csv are
-        overwritten with default values from 'data/user_inputs_collection/'
-        according to the pv plants defined in 'pv_setup'.
+        overwritten with default values from `data/user_inputs_collection/`
+        according to the pv plants defined in `pv_setup`.
+        Default: True.
     overwrite_heat_parameters: bool
         Default: True. If true, existing COP time series of the heat pump will be
         overwritten with calculated time series of COP and existing fixed thermal losses
         absolute and relative will be overwritten with calculated time series of fixed thermal
         losses relative and absolute.
+        Default: True.
     add_weather_data: str or None
-        Path to csv containing hourly weather time series with columns: [time, latitude, longitude
-        ,ghi, wind_speed, temp_air, precipitable_water, dni, dhi]
-        Default: None. If None, the ERA5 data is used instead.
+        Path to csv containing hourly weather time series with columns: [time, latitude,
+        longitude, ghi, wind_speed, temp_air, precipitable_water, dni, dhi]
+        If None, ERA5 weather data is downloaded and used.
+        Default: None.
     add_sam_si_module: dict or None
-        Dictionary with library (’CECMod’  or "SandiaMod") as key and module name as value.
-        E.g. {"cecmod":'Canadian_Solar_Inc__CS5P_220M'}.
+        Dictionary with library ("CECMod" or "SandiaMod") as key and module name as value.
+        E.g. `{"cecmod": "Canadian_Solar_Inc__CS5P_220M"}`.
         Note that the SI module is only considered if there is the technology "SI" in
-        'user_inputs/mvs_inputs/pvcompare_inputs/pv_setup.csv'
+        'user_inputs_pvcompare_directory/pv_setup.csv'
+        Default: None.
     add_electricity_demand: str or None
         Path to precalculated hourly electricity demand time series for one year (or the same period
-        of a precalculated PV timeseries)
-        Note that that the demand is only considered if a column "Electricity demand" is added to
-        'user_inputs/mvs_inputs/csv_elements/energyConsumption.csv'
+        of a precalculated PV timeseries).
+        Note that that the demand time series is only considered if you add a column with the
+        'energy_vector' "Electricity" to 'energyConsumption.csv' in
+        `user_inputs_mvs_directory/csv_elements`.
+        Default: None.
     add_heat_demand: str or None
         Path to precalculated hourly heat demand time series for one year (or the same period
         of a precalculated PV timeseries)
-        Note that that the demand is only considered is a column "Heat demand" is added to
-        'user_inputs/mvs_inputs/csv_elements/energyConsumption.csv'
+        Note that that the demand time series is only considered if you add a column with the
+        'energy_vector' "Heat" to 'energyConsumption.csv' in
+        `user_inputs_mvs_directory/csv_elements`.
+        Default: None.
     add_pv_timeseries: dict or None
-        Dictionary with {"PV1" : ["filename": >path_to_time_series< , "module_size": >module_size in m²<,
+        Dictionary in the following format:
+        {"SI1" : ["filename": >path_to_time_series< , "module_size": >module_size in m²<,
         "module_peak_power": >peak power of the module in kWp<, "surface_type": >surface_type for PV installation<],
-        "PV2" : [...], ...}. If you want to consider more PV time series, more PV keys can be added.
-        The PV time series itself needs to be be an normalized hourly time series in kW/kWp
-        (normalized by the peak power of the module). The surface_types can be one of: [
-            "flat_roof", "gable_roof", "south_facade", "east_facade", "west_facade"].
+        "SI2" : [...], ...}.
+        If you want to consider more PV time series, more PV keys can be added.
+        The PV time series itself needs to be a normalized hourly time series in kW/kWp
+        (normalized by the peak power of the module). The surface_type can be one of the
+        following: "flat_roof", "gable_roof", "south_facade", "east_facade", "west_facade".
         Note that you need to add more specific PV parameters of your module (name, costs, lifetime etc.) in
-        'user_inputs/mvs_inputs/csv_elements/energyProduction.csv'. The columns in energyProduction.csv
-        should be named "PV"+ key (e.g. "PV SI1")
-         When providing your own time series, overwrite_pv_parameters should be
-        set to false. When add_pv_timeseries is used, the pv_setup.csv is disregarded.
+        'user_inputs_mvs_directory/csv_elements/energyProduction.csv'. The columns in 'energyProduction.csv'
+        should be named "PV"+ key used in your dictionary (e.g. "PV SI1").
+        When providing your own time series, `overwrite_pv_parameters` should be
+        set to false. When `add_pv_timeseries` is used, the 'pv_setup.csv' is disregarded.
+        Default: None.
 
     Returns
     -------
-    Saves calculated time series to `timeseries` folder in `user_inputs_mvs_directory and
+    Saves calculated time series to `timeseries` folder in `user_inputs_mvs_directory` and
     updates csv files in `csv_elements` folder.
 
     """


### PR DESCRIPTION
Fix #Issue

**Changes proposed in this pull request**:
- Adaptions to docstring of `apply_pvcompare()`

The following steps were realized, as well (required):
- [x] Update the CHANGELOG.md
- [ ] Check if full simulation tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

Also the following steps were realized (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

In case of an error due to linting, run `black . --exclude docs/` and push your changes.
Note that in case you do not fix a whole issue you should start your PR with `Address #xyz`.

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
